### PR TITLE
URLに2021をつけ、rootのアクセスはリダイレクトさせる

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,6 +2,6 @@
 
 class StaticController < ApplicationController
   def index
-    redirect_to '/schedules'
+    redirect_to '/2021'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,15 @@
 
 Rails.application.routes.draw do
   root to: 'static#index'
-  resources :schedules, only: %i[index show]
-  resources :plans, only: %i[show update create] do
-    scope module: :plans do
-      resource :ogp, only: %i[show]
+
+  scope '2021' do
+    get '/', to: 'schedules#index', as: 'root_2021'
+
+    resources :schedules, only: %i[index show]
+    resources :plans, only: %i[show update create] do
+      scope module: :plans do
+        resource :ogp, only: %i[show]
+      end
     end
   end
 end


### PR DESCRIPTION
### 概要
https://rubykaigi.smarthr.co.jp/ へのアクセスは https://rubykaigi.smarthr.co.jp/2021 にリダイレクトさせたいよ

###  やったこと
* `schedules`や `plans`を 2021のscope配下にする
* `/`のアクセスを`/2021`にリダイレクトさせる
* `/2021`のアクセスは `schedules#index`を表示する