### PR TITLE
SpeakerモデルにGitHub/Twitterアカウントを保存できるようにした

### DIFF
--- a/db/migrate/20210825084019_add_social_accounts_to_speakers.rb
+++ b/db/migrate/20210825084019_add_social_accounts_to_speakers.rb
@@ -1,0 +1,8 @@
+class AddSocialAccountsToSpeakers < ActiveRecord::Migration[6.1]
+  def change
+    change_table :speakers, bulk: true do |t|
+      t.string :github
+      t.string :twitter
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_20_131711) do
+ActiveRecord::Schema.define(version: 2021_08_25_084019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2021_08_20_131711) do
     t.string "profile", default: "", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "github"
+    t.string "twitter"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,9 @@ ActiveRecord::Base.transaction do
       name: val['name'],
       handle: "@#{val['id']}",
       thumbnail: "https://www.gravatar.com/avatar/#{val['gravatar_hash']}/?s=268&d=https%3A%2F%2Frubykaigi.org%2F2020%2Fimages%2Fspeakers%2Fdummy-avatar.png",
-      profile: val['bio']
+      profile: val['bio'],
+      github: val['github_id'],
+      twitter: val['twitter_id']
     )
   end
 


### PR DESCRIPTION
### 概要
ひつようなので、Github TwitterのアカウントをSpeakerに保存できるようにしました

###  やったこと
* Speakerモデルにカラム追加
  * githubとtwitter
* `db:seed`でアカウント情報を保存できるようにした

### 確認方法
1. `./bin/rails db:seed`をする
2. consoleなどでかくにん