### PR TITLE
safariでアクセスしたときに英語のlocaleになってしまうのを日本語を修正するように変更した

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,11 @@ module Mie
     config.load_defaults 6.1
     config.middleware.use Rack::Locale
 
+    require 'i18n/backend/fallbacks'
+    I18n::Backend::Simple.include I18n::Backend::Fallbacks
+    I18n.available_locales = %i[en ja ja-jp]
+    I18n.fallbacks.map('ja-jp': :ja)
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
- safari及びmobile safariはAccept Languageヘッダがja-jpという値になる模様
- I18n.available_localesにはja-jpがないのでenを使うようになっていた
- I18n.available_localesにja-jpを追加(`<<`で追記ができなかったので、使うlocaleのリストをsetterにわたす形で対応している)し、ja-jpの定義が見つからなかったらjaにするようにしたところsafariで日本語が表示された
