### PR TITLE
Schedules画面のページサイズが異常に大きくなっていた問題に対応

### DIFF
--- a/app/helpers/react_helper.rb
+++ b/app/helpers/react_helper.rb
@@ -44,8 +44,6 @@ module ReactHelper
           added: include_plan ? I18n.t('card.added') : nil
         }
       }
-
-      props[:form][:initial] = terms_of_service_props if plan.initial?
     end
 
     props
@@ -86,6 +84,7 @@ module ReactHelper
   def create_schedule_table_props(table_array, plan, user)
     props = {}
     props[:groupedSchedules] = schedule_table_props(table_array, plan, user)
+    props[:initial] = terms_of_service_props if plan.initial?
     props[:i18n] = schedule_table_i18n
     props
   end

--- a/app/javascript/components/ScheduleCard.tsx
+++ b/app/javascript/components/ScheduleCard.tsx
@@ -34,6 +34,7 @@ export interface Props {
   form?: SubmitFormProps
   memo?: string
   memoMaxLength: number
+  initial?: InitialProps
   i18n: {
     showDetail: string
     editMemo: string
@@ -50,21 +51,22 @@ export interface SubmitFormProps {
   targetKeyName: string
   targetKey: string
   buttonText: string
-  initial?: {
-    title: string
-    description: string
-    termsOfService: string
-    close: string
-    accept: string
-  }
   mode: Mode
   i18n: {
     added: string | null
   }
 }
 
+export interface InitialProps {
+  title: string
+  description: string
+  termsOfService: string
+  close: string
+  accept: string
+}
+
 export const ScheduleCard: React.VFC<Props> = (props) => {
-  const { title, mode, description, speakers, language, memo, memoMaxLength, form, i18n, details } = props
+  const { title, mode, description, speakers, language, memo, memoMaxLength, form, initial, i18n, details } = props
   const [isDetailOpen, setIsDetailOpen] = useState(false)
   const [isMemoEditing, setIsMemoEditing] = useState(false)
 
@@ -128,7 +130,7 @@ export const ScheduleCard: React.VFC<Props> = (props) => {
           </UpdateMemoButton>
           : null
         }
-        <MarginWrapper>{ form ? <SubmitForm {...form} /> : null }</MarginWrapper>
+        <MarginWrapper>{ form ? <SubmitForm {...form} initial={initial} /> : null }</MarginWrapper>
         <MarginWrapper><TextButton size="s" onClick={() => setIsDetailOpen(true)}><Text size="S" weight="bold" color="TEXT_BLACK">{i18n.showDetail}</Text></TextButton></MarginWrapper>
       </Actions>
       <ScheduleDetail {...detailProps} />

--- a/app/javascript/components/ScheduleTable.tsx
+++ b/app/javascript/components/ScheduleTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { TabBar, TabItem, ThemeProvider } from 'smarthr-ui'
-import { ScheduleCard, Props as CardProps } from './ScheduleCard'
+import { ScheduleCard, Props as CardProps, InitialProps } from './ScheduleCard'
 import { Table, TableHead, TableBody, TableRow, TableHeadCell, TableBodyCell } from './Shared/Table'
 import { ScheduleTime } from './Shared/ScheduleTime';
 import createdTheme from "./Constants";
@@ -14,13 +14,14 @@ type Row = { time: string, schedules: Array<CardProps | null> }
 
 interface Props {
   groupedSchedules: GroupedSchedules
+  initial?: InitialProps
   i18n: {
     startEnd: string
   }
 }
 
 export const ScheduleTable: React.VFC<Props> = (props) => {
-  const { groupedSchedules, i18n } = props
+  const { groupedSchedules, initial, i18n } = props
   const current = window.location.hash === "" ? Object.keys(groupedSchedules)[0] : window.location.hash.replace('#', '')
 
 
@@ -54,7 +55,15 @@ export const ScheduleTable: React.VFC<Props> = (props) => {
                     <TableBodyCell noSidePadding as="th">
                       <ScheduleTime time={row.time}/>
                     </TableBodyCell>
-                    {row.schedules.map((schedule, index) => schedule === null ? <TableBodyCell key={index} /> : <TableBodyCell key={index}><CellItemStretcher><ScheduleCard {...schedule} /></CellItemStretcher></TableBodyCell>)}
+                    {row.schedules.map((schedule, index) =>
+                      schedule === null ?
+                        <TableBodyCell key={index} />
+                        : <TableBodyCell key={index}>
+                          <CellItemStretcher>
+                            <ScheduleCard {...schedule} initial={initial} />
+                          </CellItemStretcher>
+                        </TableBodyCell>
+                    )}
                   </TableRow>
                 )
               })}


### PR DESCRIPTION
# 原因

各Cardのコンポーネントに渡すPropsに、利用規約全文がそれぞれ入っていたために重すぎた

# 対応

利用規約はScheduleTableのPropsとして扱い、各カードはScheduleTableからinitial情報を受け取るように変更する

# 結果

ローカル環境で3.6MB => 252KBに縮小

実施前

<img width="1438" alt="スクリーンショット 2021-09-01 16 10 43" src="https://user-images.githubusercontent.com/2846039/131628162-e573d0ea-df25-413a-a963-d094065de7c0.png">

実施後

<img width="1438" alt="スクリーンショット 2021-09-01 16 13 29" src="https://user-images.githubusercontent.com/2846039/131628344-c6c9ab9b-090e-471b-a32b-75690c9809c8.png">

