### PR TITLE
英語のアプリケーション紹介文にダブルクオートが足りなかったので追加した

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,7 +110,7 @@ en:
 
   application:
     intro: |-
-      RubyKaigi Takeout 2021 Schedule.select" is RubyKaigi's first official schedule creation and sharing app. You can list the sessions you are interested in and create your own viewing schedule!
+      "RubyKaigi Takeout 2021 Schedule.select" is RubyKaigi's first official schedule creation and sharing app. You can list the sessions you are interested in and create your own viewing schedule!
       If you have ever wondered, "Which session should I watch…" before attending a conference, then this is the app for you.
       We developed this app so participants could share their "viewing schedules" and "reasons for interest" before the event, which they could use as a reference for session selection and to enjoy the conference even more.
       Why do you want to see the session? Share it before the event and let's enjoy RubyKaigi Takeout 2021 together!


### PR DESCRIPTION
### 概要
RubyKaigi側から指摘のあった点の修正。
英語のアプリ紹介文のダブルクオートが足りなかったので修正しました。

### やったこと
ダブルクオートを足した
* before: `RubyKaigi Takeout 2021 Schedule.select"`
* after: `"RubyKaigi Takeout 2021 Schedule.select"`