### PR TITLE
Add new model Event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Event < ApplicationRecord
+  validates :name, presence: true, length: { in: 1..32 }
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -40,6 +40,7 @@ class Plan < ApplicationRecord
   include BCrypt
 
   belongs_to :user
+  belongs_to :event
   has_many :plan_schedules
   has_many :schedules, through: :plan_schedules
 

--- a/app/models/plan_schedule.rb
+++ b/app/models/plan_schedule.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class PlanSchedule < ApplicationRecord
+  include ActiveModel::Validations
+  validates_with Validators::EventEqualityValidator
+
   belongs_to :plan
   belongs_to :schedule
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -5,6 +5,8 @@ class Schedule < ApplicationRecord
   has_many :speakers, through: :schedule_speakers
   has_many :plan_schedules
 
+  belongs_to :event
+
   enum language: { en: 0, ja: 1, 'en & ja': 2 }
 
   validates :title, presence: true, length: { in: 1..100 }

--- a/app/models/schedule_speaker.rb
+++ b/app/models/schedule_speaker.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ScheduleSpeaker < ApplicationRecord
+  include ActiveModel::Validations
+  validates_with Validators::EventEqualityValidator
+
   belongs_to :schedule
   belongs_to :speaker
 end

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -4,6 +4,8 @@ class Speaker < ApplicationRecord
   has_many :schedule_speakers
   has_many :schedules, through: :schedule_speakers
 
+  belongs_to :event
+
   validates :name, presence: true, length: { in: 1..100 }
   validates :handle, length: { in: 0..100 }
   validates :profile, length: { in: 0..1024 }

--- a/app/models/validators/event_equality_validator.rb
+++ b/app/models/validators/event_equality_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Validators
+  class EventEqualityValidator < ActiveModel::Validator
+    RELATIONS = %i[plan schedule speaker].freeze
+
+    def validate(record)
+      RELATIONS.inject(nil) do |acc, relation|
+        next acc unless record.respond_to?(relation) && record.send(relation)&.event_id
+
+        acc ||= record.send(relation).event_id
+
+        if acc && acc != record.send(relation).event_id
+          record.errors.add relation, 'Event id must be same in cross relations.'
+        end
+
+        acc
+      end
+    end
+  end
+end

--- a/db/migrate/20230214191702_create_events.rb
+++ b/db/migrate/20230214191702_create_events.rb
@@ -1,0 +1,9 @@
+class CreateEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :events, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230214192924_add_references_to_events.rb
+++ b/db/migrate/20230214192924_add_references_to_events.rb
@@ -1,0 +1,29 @@
+class AddReferencesToEvents < ActiveRecord::Migration[6.1]
+  def up
+    add_column :plans, :event_id, :uuid, foreign_key: true
+    add_column :schedules, :event_id, :uuid, foreign_key: true
+    add_column :speakers, :event_id, :uuid, foreign_key: true
+
+
+    Event.create!(name: 'test') if Event.count == 0
+    default_event = Event.first
+
+    Plan.reset_column_information
+    Schedule.reset_column_information
+    Speaker.reset_column_information
+
+    Plan.update_all(event_id: default_event.id)
+    Schedule.update_all(event_id: default_event.id)
+    Speaker.update_all(event_id: default_event.id)
+
+    change_column :plans, :event_id, :uuid, foreign_key: true, null: false
+    change_column :schedules, :event_id, :uuid, foreign_key: true, null: false
+    change_column :speakers, :event_id, :uuid, foreign_key: true, null: false
+  end
+
+  def down
+    remove_column :plans, :event_id
+    remove_column :schedules, :event_id
+    remove_column :speakers, :event_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_084641) do
+ActiveRecord::Schema.define(version: 2023_02_14_192924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "plan_schedules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "plan_id", null: false
@@ -33,6 +39,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_084641) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "password_hash"
     t.boolean "initial", default: true, null: false
+    t.uuid "event_id", null: false
   end
 
   create_table "schedule_speakers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -51,6 +58,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_084641) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "track_name", null: false
     t.integer "language", default: 0, null: false
+    t.uuid "event_id", null: false
   end
 
   create_table "speakers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -62,6 +70,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_084641) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "github"
     t.string "twitter"
+    t.uuid "event_id", null: false
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,10 +9,12 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 ActiveRecord::Base.transaction do
+  rubykaigi2021 = Event.create!(name: 'rubykaigi2021')
+
   speakers_yaml = {}.merge(*YAML.load_file('db/seeds/speakers.yml').values)
 
   speakers_by_id = speakers_yaml.transform_values do |val|
-    speaker = Speaker.find_or_initialize_by(handle: "@#{val['id']}")
+    speaker = Speaker.find_or_initialize_by(handle: "@#{val['id']}", event: rubykaigi2021)
     speaker.update!(
       name: val['name'],
       thumbnail: "https://www.gravatar.com/avatar/#{val['gravatar_hash']}/?s=268&d=https%3A%2F%2Frubykaigi.org%2F2020%2Fimages%2Fspeakers%2Fdummy-avatar.png",
@@ -30,7 +32,7 @@ ActiveRecord::Base.transaction do
 
   if ENV['SCHEDULE_FIND_BY'] == 'title'
     schedules_by_id = presentation_yaml.transform_values do |val|
-      schedule = Schedule.find_or_initialize_by(title: val['title'])
+      schedule = Schedule.find_or_initialize_by(title: val['title'], event: rubykaigi2021)
       schedule.attributes = {
         description: val['description'],
         language: val['language'].downcase
@@ -51,7 +53,8 @@ ActiveRecord::Base.transaction do
           schedule.update!(
             track_name: "Track#{track_name}",
             start_at: start_at,
-            end_at: end_at
+            end_at: end_at,
+            event: rubykaigi2021
           )
         end
       end
@@ -68,7 +71,8 @@ ActiveRecord::Base.transaction do
           hash[id] = Schedule.find_or_initialize_by(
             track_name: "Track#{track_name}",
             start_at: start_at,
-            end_at: end_at
+            end_at: end_at,
+            event: rubykaigi2021
           )
         end
       end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,2 +1,4 @@
 party:
   name: 'Happy party'
+dojo:
+  name: 'Programming dojo'

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,2 @@
+party:
+  name: 'Happy party'

--- a/test/fixtures/plans.yml
+++ b/test/fixtures/plans.yml
@@ -4,3 +4,4 @@ one:
   description: "Plans for test"
   user: one
   public: true
+  event: party

--- a/test/fixtures/plans.yml
+++ b/test/fixtures/plans.yml
@@ -5,3 +5,10 @@ one:
   user: one
   public: true
   event: party
+
+two:
+  title: "Test plan 1"
+  description: "Plans for dojo"
+  user: two
+  public: true
+  event: dojo

--- a/test/fixtures/schedules.yml
+++ b/test/fixtures/schedules.yml
@@ -44,3 +44,12 @@ five:
   track_name: TrackC
   language: 1
   event: party
+
+dojo_one:
+  title: "Schedule title 1 in Dojo"
+  description: "This is Schedule title 1 in Dojo description"
+  start_at: 2022-12-31 10:00:00
+  end_at: 2023-01-01 10:40:00
+  track_name: TrackA
+  language: 0
+  event: dojo

--- a/test/fixtures/schedules.yml
+++ b/test/fixtures/schedules.yml
@@ -7,6 +7,7 @@ one:
   end_at: 2021-07-20 10:40:00
   track_name: TrackA
   language: 0
+  event: party
 
 two:
   title: "Schedule title 2"
@@ -15,6 +16,7 @@ two:
   end_at: 2021-07-20 11:40:00
   track_name: TrackB
   language: 0
+  event: party
 
 three:
   title: "Schedule title 3"
@@ -23,6 +25,7 @@ three:
   end_at: 2021-07-21 10:40:00
   track_name: TrackA
   language: 1
+  event: party
 
 four:
   title: "Schedule title 4"
@@ -31,6 +34,7 @@ four:
   end_at: 2021-07-21 11:40:00
   track_name: TrackB
   language: 1
+  event: party
 
 five:
   title: "Schedule title 5"
@@ -39,3 +43,4 @@ five:
   end_at: 2021-07-21 11:40:00
   track_name: TrackC
   language: 1
+  event: party

--- a/test/fixtures/speakers.yml
+++ b/test/fixtures/speakers.yml
@@ -5,27 +5,32 @@ johnny:
   handle: silverhand
   thumbnail: "https://example.com/thumbnail1"
   profile: rockerboy
+  event: party
 
 kerry:
   name: "Kerry Eurodyne"
   handle: ponponshit
   thumbnail: "https://example.com/thumbnail2"
   profile: rockerboy
+  event: party
 
 nancy:
   name: "Nancy"
   handle: besisis
   thumbnail: "https://example.com/thumbnail3"
   profile: freak
+  event: party
 
 henry:
   name: "Henry"
   handle: henry
   thumbnail: "https://example.com/thumbnail4"
   profile: gold
+  event: party
 
 denny:
   name: "Denny"
   handle: denny
   thumbnail: "https://example.com/thumbnail5"
   profile: hello
+  event: party

--- a/test/fixtures/speakers.yml
+++ b/test/fixtures/speakers.yml
@@ -34,3 +34,10 @@ denny:
   thumbnail: "https://example.com/thumbnail5"
   profile: hello
   event: party
+
+cat:
+  name: "Cat"
+  handle: "space cat"
+  thumbnail: "https://example.com/thumbnail6"
+  profile: meow
+  event: dojo

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class EventTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/plan_schedule_test.rb
+++ b/test/models/plan_schedule_test.rb
@@ -3,7 +3,13 @@
 require 'test_helper'
 
 class PlanScheduleTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'assign schedule to plan on same event' do
+    target = PlanSchedule.create(schedule: schedules(:one), plan: plans(:one))
+    assert target.valid?
+  end
+
+  test "Can't assign schedule to plan managed by other event" do
+    target = PlanSchedule.create(schedule: schedules(:dojo_one), plan: plans(:one))
+    assert target.invalid?
+  end
 end

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -52,7 +52,7 @@ class PlanTest < ActiveSupport::TestCase
   test "Can't select schedules that same start-end time" do
     schs = schedules(:four, :five)
 
-    p = Plan.create!(title: 'test', user: User.create!)
+    p = Plan.create!(title: 'test', user: User.create!, event: events(:party))
     p.plan_schedules.create(schedule: schs[0])
     p.plan_schedules.create(schedule: schs[1])
     assert_not p.valid?
@@ -65,17 +65,19 @@ class PlanTest < ActiveSupport::TestCase
       track_name: 'test track',
       speakers: [johnny],
       start_at: Time.zone.parse('2021-07-30 12:00:00'),
-      end_at: Time.zone.parse('2021-07-30 13:00:00')
+      end_at: Time.zone.parse('2021-07-30 13:00:00'),
+      event: events(:party)
     )
     right = Schedule.create!(
       title: 'test2',
       track_name: 'test track',
       speakers: [kerry],
       start_at: Time.zone.parse('2021-07-30 12:30:00'),
-      end_at: Time.zone.parse('2021-07-30 13:20:00')
+      end_at: Time.zone.parse('2021-07-30 13:20:00'),
+      event: events(:party)
     )
 
-    p = Plan.create!(title: 'test', user: User.create!)
+    p = Plan.create!(title: 'test', user: User.create!, event: events(:party))
     p.plan_schedules.create(schedule: left)
     p.plan_schedules.create(schedule: right)
     assert_not p.valid?
@@ -88,17 +90,19 @@ class PlanTest < ActiveSupport::TestCase
       track_name: 'test track',
       speakers: [johnny],
       start_at: Time.zone.parse('2021-07-30 12:00:00'),
-      end_at: Time.zone.parse('2021-07-30 13:00:00')
+      end_at: Time.zone.parse('2021-07-30 13:00:00'),
+      event: events(:party)
     )
     right = Schedule.create!(
       title: 'test2',
       track_name: 'test track',
       speakers: [kerry],
       start_at: Time.zone.parse('2021-07-30 13:00:00'),
-      end_at: Time.zone.parse('2021-07-30 14:00:00')
+      end_at: Time.zone.parse('2021-07-30 14:00:00'),
+      event: events(:party)
     )
 
-    p = Plan.create!(title: 'test', user: User.create!)
+    p = Plan.create!(title: 'test', user: User.create!, event: events(:party))
     p.plan_schedules.create(schedule: left)
     p.plan_schedules.create(schedule: right)
     assert p.valid?

--- a/test/models/schedule_speaker_test.rb
+++ b/test/models/schedule_speaker_test.rb
@@ -3,7 +3,13 @@
 require 'test_helper'
 
 class ScheduleSpeakerTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'assign speaker to schedule on same event' do
+    target = ScheduleSpeaker.create(schedule: schedules(:dojo_one), speaker: speakers(:cat))
+    assert target.valid?
+  end
+
+  test "Can't assign speaker to schedule managed by other event" do
+    target = ScheduleSpeaker.create(schedule: schedules(:dojo_one), speaker: speakers(:johnny))
+    assert target.invalid?
+  end
 end


### PR DESCRIPTION
For manage some events, add new table events and Event model.
Plan, Schedule and Speakers are belongs to Event to separate by routing.

- Add new table events
- Add relations for event
- Add validator to check each relation objects don't cross event