### PR TITLE
Support for more than 3 tracks.

### DIFF
--- a/app/javascript/components/LocaleSelector.tsx
+++ b/app/javascript/components/LocaleSelector.tsx
@@ -35,9 +35,9 @@ export const LocaleSelector: React.VFC<Props> = (props) => {
 };
 
 const ResizedSelect = styled(Select)`
-  height: 30px !important;
   select {
     padding: 3px 8px;
+    min-height: 30px;
   }
 `
 

--- a/app/javascript/components/ScheduleCard.tsx
+++ b/app/javascript/components/ScheduleCard.tsx
@@ -216,6 +216,7 @@ const Card = styled(Base)`
 
 const Speaker = styled.div`
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
 `
@@ -223,6 +224,8 @@ const Speaker = styled.div`
 const Profile = styled.div`
   display: flex;
   align-items: center;
+  min-width: 320px;
+  margin-bottom: 8px;
 `
 
 const MarginWrapper = styled.div`
@@ -256,7 +259,7 @@ const Lng = styled.div`
   justify-content: center;
   align-items: center;
   padding: 0px 12px;
-  margin-left: 8px;
+  margin-right: 8px;
 
   height: 24px;
   left: 330.5px;

--- a/app/javascript/components/ScheduleTable.tsx
+++ b/app/javascript/components/ScheduleTable.tsx
@@ -44,8 +44,8 @@ export const ScheduleTable: React.VFC<Props> = (props) => {
           <Table>
             <TableHead>
               <TableRow>
-                <TableHeadCell width="20%">{i18n.startEnd}</TableHeadCell>
-                {groupedSchedules[currentKey].trackList.map((track, index) => <TableHeadCell key={index}  width="40%" textCenter>{track}</TableHeadCell>)}
+                <TableHeadCell minWidth={"150px"}>{i18n.startEnd}</TableHeadCell>
+                {groupedSchedules[currentKey].trackList.map((track, index) => <TableHeadCell key={index} textCenter>{track}</TableHeadCell>)}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -81,6 +81,7 @@ const Wrapper = styled.div`
 `
 const TableWrapper = styled.div`
   margin-top: 16px;
+  overflow-y: auto;
 `
 /* テーブルセル内の要素の幅高さ 100% にする */
 const CellItemStretcher = styled.div`
@@ -88,6 +89,7 @@ const CellItemStretcher = styled.div`
   height: 100%;
   > * {
     width: 100%;
+    min-width: 400px;
   }
 `
 

--- a/app/javascript/components/Shared/Table.tsx
+++ b/app/javascript/components/Shared/Table.tsx
@@ -4,6 +4,7 @@ const borderColor = '#D6D3D0'
 
 export const Table = styled.table`
   height: 100%; /* cell 内の要素の高さを 100% にするために必要 */
+  width: 100%;
 `
 export const TableHead = styled.thead``
 export const TableRow = styled.tr``
@@ -12,11 +13,12 @@ export const TableBody = styled.tbody`
     padding-top: 16px;
   }
 `
-export const TableHeadCell = styled.th<{ width?: string, textCenter?: boolean }>`
+export const TableHeadCell = styled.th<{ width?: string, minWidth?: string, textCenter?: boolean }>`
   padding: 16px;
   font-size: 14px;
   border: solid 1px ${borderColor};
   width: ${({width}) => width ? width : 'auto'};
+  min-width: ${({minWidth}) => minWidth ? minWidth : 'auto'};
   text-align: ${({textCenter}) => textCenter ? 'center' : 'left'};
 `
 export const TableBodyCell = styled.td<{ noSidePadding?: boolean }>`


### PR DESCRIPTION
- Support for more than 3 tracks.
  - Set minWidth for items with collapsed layouts
  - Allows horizontal scrolling when needed
  - Changed to be more comfortable with a narrower ScheduleCard
- Modified Locale Selector to conform to changes in SmartHRUI components

https://user-images.githubusercontent.com/20836073/233989476-42189b90-47da-4d56-bb8a-ea1b8a8950e2.mov


ScheduleCard is used on the plans page, but this modification does not almost affect it.
<img width="1520" alt="image" src="https://user-images.githubusercontent.com/20836073/233991393-26b013a6-257e-4d37-9085-e8046874a9cd.png">
