### PR TITLE
fix-initial-migration-failed

### DIFF
--- a/db/migrate/20230214192924_add_references_to_events.rb
+++ b/db/migrate/20230214192924_add_references_to_events.rb
@@ -1,13 +1,16 @@
 class AddReferencesToEvents < ActiveRecord::Migration[6.1]
+  class MigrationEvent < ActiveRecord::Base
+    self.table_name = :events
+  end
+
   def up
     add_column :plans, :event_id, :uuid, foreign_key: true
     add_column :schedules, :event_id, :uuid, foreign_key: true
     add_column :speakers, :event_id, :uuid, foreign_key: true
 
 
-    Event.create!(name: 'test') if Event.count == 0
-    default_event = Event.first
-
+    MigrationEvent.create!(name: 'test') if MigrationEvent.count == 0
+    default_event = MigrationEvent.first
     Plan.reset_column_information
     Schedule.reset_column_information
     Speaker.reset_column_information


### PR DESCRIPTION
```
== 20230214192924 AddReferencesToEvents: migrating ============================
-- add_column(:plans, :event_id, :uuid, {:foreign_key=>true})
   -> 0.0025s
-- add_column(:schedules, :event_id, :uuid, {:foreign_key=>true})
   -> 0.0010s
-- add_column(:speakers, :event_id, :uuid, {:foreign_key=>true})
   -> 0.0009s
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Validation failed: Event theme can't be blank
/Users/soul/projects/exSOUL/mie/db/migrate/20230214192924_add_references_to_events.rb:8:in `up'

Caused by:
ActiveRecord::RecordInvalid: Validation failed: Event theme can't be blank
/Users/soul/projects/exSOUL/mie/db/migrate/20230214192924_add_references_to_events.rb:8:in `up'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

en:
During `Event.create!(name: 'test')`, it's getting caught on the validation of `event_themes` table that hasn't been created yet.

As a solution, although validate: false was an option, to eliminate the dependency issue, I adopted the method of defining a new class that inherits from ActiveRecord::Base, which was suggested by ChatGPT.

ja:
`Event.create!(name: 'test')` の際にまだ作成されていないテーブルのValidateに引っかかっていた

解決策として、`validate: false` もあったが、依存関係の問題を排除するために(ChatGPTに教えてもらった) `ActiveRecord::Base` を継承した新たなクラスを定義する方法を採用した

[imao]
`Event.create!(name: 'test') if Event.count == 0` から始まる一連のupdate処理、今後新たにmieを触る人には不要かもなので思い切って消しちゃうのもありなのかもと思いました