### PR TITLE
Refactor schedule table object

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -6,8 +6,7 @@ class SchedulesController < ApplicationController
 
   def index
     @schedules = Schedule.on_event(@event).includes(:speakers).order(:start_at)
-    @table_array = create_table_array(@schedules)
-    @schedule_table = schedule_table(@table_array)
+    @schedule_table = Schedule::Tables.new(@schedules)
   end
 
   def dialog

--- a/app/models/schedule/table.rb
+++ b/app/models/schedule/table.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Schedule
+  class Table
+    attr_reader :track_list, :rows
+
+    def initialize(schedules)
+      @track_list = schedules.map(&:track_name).sort.uniq
+
+      grouped_schedules = schedules.group_by do |s|
+        start_at = I18n.l(s.start_at, format: :timetable)
+        end_at = I18n.l(s.end_at, format: :timetable)
+        zone = s.end_at.strftime('%Z')
+
+        "#{start_at} - #{end_at} (#{zone})"
+      end
+
+      @rows = grouped_schedules.map { |_, v| Schedule::Table::Row.new(v) }.sort_by(&:sort_key)
+    end
+  end
+end

--- a/app/models/schedule/table/row.rb
+++ b/app/models/schedule/table/row.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Schedule
+  class Table
+    class Row
+      attr_reader :start_end, :timezone, :schedules, :tracks, :sort_key
+
+      def initialize(schedules)
+        start_at = I18n.l(schedules[0].start_at, format: :timetable)
+        end_at = I18n.l(schedules[0].end_at, format: :timetable)
+
+        @start_end = "#{start_at} - #{end_at}"
+        @timezone = schedules[0].end_at.strftime('%Z')
+        @schedules = schedules
+        @tracks = schedules.map { [_1.track_name, _1] }.to_h
+        @sort_key = schedules[0].start_at
+      end
+    end
+  end
+end

--- a/app/models/schedule/tables.rb
+++ b/app/models/schedule/tables.rb
@@ -12,7 +12,7 @@ class Schedule
     end
 
     def days
-      @map.keys.sort_by(&:to_i)
+      @map.keys.sort_by { Time.parse(_1).to_i }
     end
 
     def [](key)

--- a/app/models/schedule/tables.rb
+++ b/app/models/schedule/tables.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Schedule
+  class Tables
+    DATE_FORMAT = '%Y-%m-%d'
+
+    def initialize(schedules)
+      @schedules = schedules
+      @map = @schedules.group_by { _1.start_at.strftime(DATE_FORMAT) }.transform_values do |v|
+        Schedule::Table.new(v)
+      end
+    end
+
+    def days
+      @map.keys.sort_by(&:to_i)
+    end
+
+    def [](key)
+      @map[key]
+    end
+  end
+end

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -13,39 +13,39 @@
 <div data-controller="schedule-table" class="max-w-[1120px] mx-auto">
   <div class="flex overflow-x-auto overflow-y-hidden gap-2 p-0">
     <div class="relative flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
-      <% @table_array.keys.map do |k| %>
-        <button data-action="click->schedule-table#switch" value="<%= k %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
-          <%= k %>
+      <% @schedule_table.days.each do |day| %>
+        <button data-action="click->schedule-table#switch" value="<%= day %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
+          <%= day %>
         </button>
       <% end %>
     </div>
   </div>
   <div class="mt-4 overflow-y-auto">
-    <% @schedule_table.each do |k, v| %>
-      <div id="schedule-<%= k %>" class="schedule-table hidden">
+    <% @schedule_table.days.each do |day| %>
+      <div id="schedule-<%= day %>" class="schedule-table hidden">
         <table class="h-full w-full border-collapse border-spacing-0">
           <thead>
             <th class="p-4 text-sm leading-4 border border-solid border-[rgb(214,211,208)] w-auto min-w-[184px] text-left"><%= I18n.t('table.start_end') %></th>
-            <% v[:track_list].each do |track| %>
+            <% @schedule_table[day].track_list.each do |track| %>
               <th class="p-4 text-sm leading-4 border border-solid border-[rgb(214,211,208)] w-auto text-center"><%= track %></th>
             <% end %>
           </thead>
           <tbody>
-            <% v[:rows].each do |row| %>
-              <% @selected = @plan.plan_schedules.map(&:schedule).any? { row[:schedules].include?(_1) } %>
+            <% @schedule_table[day].rows.each do |row| %>
+              <% @selected = @plan.plan_schedules.map(&:schedule).any? { row.schedules.include?(_1) } %>
               <tr class="align-baseline">
                 <th class="py-2 px-0 align-baseline">
                   <div class="flex flex-col gap-1">
                     <div class="flex items-center">
-                      <p class="text-xl font-normal mr-4 shrink-0"><%= row[:time][:range] %></p>
+                      <p class="text-xl font-normal mr-4 shrink-0"><%= row.start_end %></p>
                       <hr class="w-full h-[1px] mr-4 bg-[rgb(214,211,208)] border-none">
                     </div>
-                    <p class="text-sm font-bold text-[rgb(112,109,101)] text-left"><%= row[:time][:zone] %></p>
+                    <p class="text-sm font-bold text-[rgb(112,109,101)] text-left"><%= row.timezone %></p>
                   </div>
                 </th>
-                <% row[:schedules].each do |schedule| %>
+                <% @schedule_table[day].track_list.each do |track| %>
                     <td>
-                      <div class="p-2"><%= schedule ? render("schedules/card", schedule:, mode: :schedule, inactive: @selected) : nil %></div>
+                      <div class="p-2"><%= row.tracks[track] ? render("schedules/card", schedule: row.tracks[track], mode: :schedule, inactive: @selected) : nil %></div>
                     </td>
                 <% end %>
               </tr>

--- a/test/models/schedule/table/row_test.rb
+++ b/test/models/schedule/table/row_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Schedule
+  class Table
+    class RowTest < ActiveSupport::TestCase
+      def setup
+        schedules = Schedule.where(event: events(:kaigi))
+        @tables = Schedule::Tables.new(schedules)
+      end
+
+      test 'each rows mapping correct track infomations with fixture' do
+        day1 = @tables['2024-03-18']
+
+        assert_equal day1.rows[0].start_end, '10:00 - 10:30'
+        assert_equal day1.rows[0].tracks['TrackA'], schedules(:kaigi_day1_time1_track1)
+
+        assert_equal day1.rows[1].start_end, '10:40 - 11:00'
+        assert_equal day1.rows[1].tracks['TrackA'], schedules(:kaigi_day1_time2_track1)
+        assert_equal day1.rows[1].tracks['TrackB'], schedules(:kaigi_day1_time2_track2)
+        assert_equal day1.rows[1].tracks['TrackC'], schedules(:kaigi_day1_time2_track3)
+
+        assert_equal day1.rows[2].start_end, '11:10 - 11:30'
+        assert_equal day1.rows[2].tracks['TrackA'], schedules(:kaigi_day1_time3_track1)
+        assert_equal day1.rows[2].tracks['TrackB'], schedules(:kaigi_day1_time3_track2)
+
+        assert_equal day1.rows[3].start_end, '11:45 - 12:30'
+        assert_equal day1.rows[3].tracks['TrackA'], schedules(:kaigi_day1_time4_track1)
+
+        day2 = @tables['2024-03-19']
+
+        assert_equal day2.rows[0].start_end, '09:00 - 09:30'
+        assert_equal day2.rows[0].tracks['TrackA'], schedules(:kaigi_day2_time1_track1)
+        assert_equal day2.rows[0].tracks['TrackB'], schedules(:kaigi_day2_time1_track2)
+        assert_equal day2.rows[0].tracks['TrackC'], schedules(:kaigi_day2_time1_track3)
+
+        assert_equal day2.rows[1].start_end, '10:00 - 10:30'
+        assert_equal day2.rows[1].tracks['TrackA'], schedules(:kaigi_day2_time2_track1)
+        assert_equal day2.rows[1].tracks['TrackB'], schedules(:kaigi_day2_time2_track2)
+
+        assert_equal day2.rows[2].start_end, '10:40 - 11:10'
+        assert_equal day2.rows[2].tracks['TrackA'], schedules(:kaigi_day2_time3_track1)
+        assert_equal day2.rows[2].tracks['TrackB'], schedules(:kaigi_day2_time3_track2)
+
+        assert_equal day2.rows[3].start_end, '13:00 - 14:00'
+        assert_equal day2.rows[3].tracks['TrackA'], schedules(:kaigi_day2_time4_track1)
+      end
+    end
+  end
+end

--- a/test/models/schedule/table_test.rb
+++ b/test/models/schedule/table_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Schedule
+  class TableTest < ActiveSupport::TestCase
+    def setup
+      schedules = Schedule.where(event: events(:kaigi))
+      tables = Schedule::Tables.new(schedules)
+      @table = tables[tables.days.first]
+    end
+
+    test '#track_list returns track names array' do
+      assert_equal @table.track_list, %w[TrackA TrackB TrackC]
+    end
+
+    test '#rows retuns arrays of Schedule::Table::Row' do
+      assert @table.rows.all? { _1.instance_of?(Schedule::Table::Row) }
+    end
+
+    test '#rows returns array sorted by track start time' do
+      assert_equal @table.rows.map { _1.tracks['TrackA'] }, @table.rows.map { _1.tracks['TrackA'] }.sort_by(&:start_at)
+    end
+  end
+end

--- a/test/models/schedule/tables_test.rb
+++ b/test/models/schedule/tables_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Schedule
+  class TablesTest < ActiveSupport::TestCase
+    def setup
+      schedules = Schedule.where(event: events(:kaigi))
+      @tables = Schedule::Tables.new(schedules)
+    end
+
+    test 'schedule table can return days of timetables orderd by asc' do
+      assert_equal @tables.days, %w[2024-03-18 2024-03-19]
+    end
+
+    test '[] method returns Schedule::Table' do
+      assert_equal @tables[@tables.days.first].class, Schedule::Table
+    end
+  end
+end


### PR DESCRIPTION
スケジュールページのテーブルを作成するためのオブジェクトが、SmartHR UIに渡すためのピュアなHashとArrayに頼り切った不安定な物になっていたため、今後手を加えやすいようにオブジェクト化した。