### PR TITLE
TrackをModelに切り出し、ソートを可能にする

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -5,7 +5,7 @@ class SchedulesController < ApplicationController
   include ScheduleTable
 
   def index
-    @schedules = Schedule.on_event(@event).includes(:speakers).order(:start_at)
+    @schedules = Schedule.on_event(@event).includes(:speakers, :track).order(:start_at)
     @schedule_table = Schedule::Tables.new(@schedules)
   end
 

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -5,7 +5,7 @@ class SchedulesController < ApplicationController
   include ScheduleTable
 
   def index
-    @schedules = Schedule.on_event(@event).includes(:speakers, :track).order(:start_at)
+    @schedules = @event.schedules.includes(:speakers, :track).order(:start_at)
     @schedule_table = Schedule::Tables.new(@schedules)
   end
 

--- a/app/javascript/controllers/locale_controller.js
+++ b/app/javascript/controllers/locale_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
   static values = { current: { type: String, default: '' } };
 
   connect () {
-    if (this.currentValue === '') {
+    if (this.currentValue === '' && !this.isTestEnvironment) {
       Turbo.visit(this.nonSearchParamURL(window.location) + '?' + new URLSearchParams({ locale: dayjs.tz.guess() }));
     }
   }
@@ -24,5 +24,15 @@ export default class extends Controller {
 
   nonSearchParamURL (location) {
     return location.toString().split('?')[0];
+  }
+
+  get isTestEnvironment() {
+    const railsEnv = document.head.querySelector("meta[name=rails_env]")
+    if ( railsEnv === null ) {
+      return false;
+    } else {
+      return railsEnv.content === "test"
+    }
+
   }
 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@
 
 class Event < ApplicationRecord
   has_one :event_theme, dependent: :destroy
+  has_many :tracks
 
   validates :name, presence: true, length: { in: 1..32 }
   validates :event_theme, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,12 @@
 class Event < ApplicationRecord
   has_one :event_theme, dependent: :destroy
   has_many :tracks
+  has_many :speakers
 
   validates :name, presence: true, length: { in: 1..32 }
   validates :event_theme, presence: true
+
+  def schedules
+    Schedule.where(track: tracks)
+  end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 class Schedule < ApplicationRecord
-  include Events
-
   has_many :schedule_speakers
   has_many :speakers, through: :schedule_speakers
   has_many :plan_schedules
 
-  belongs_to :event
   belongs_to :track
 
   enum language: { en: 0, ja: 1, 'en & ja': 2 }

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,11 +8,11 @@ class Schedule < ApplicationRecord
   has_many :plan_schedules
 
   belongs_to :event
+  belongs_to :track
 
   enum language: { en: 0, ja: 1, 'en & ja': 2 }
 
   validates :title, presence: true, length: { in: 1..100 }
   validates :description, length: { in: 0..1024 }
-  validates :track_name, presence: true, length: { in: 1..32 }
   validates :language, presence: true
 end

--- a/app/models/schedule/table.rb
+++ b/app/models/schedule/table.rb
@@ -5,7 +5,7 @@ class Schedule
     attr_reader :track_list, :rows
 
     def initialize(schedules)
-      @track_list = schedules.map(&:track_name).sort.uniq
+      @track_list = schedules.map(&:track).uniq.sort_by(&:position).map(&:name)
 
       grouped_schedules = schedules.group_by do |s|
         start_at = I18n.l(s.start_at, format: :timetable)

--- a/app/models/schedule/table/row.rb
+++ b/app/models/schedule/table/row.rb
@@ -12,7 +12,7 @@ class Schedule
         @start_end = "#{start_at} - #{end_at}"
         @timezone = schedules[0].end_at.strftime('%Z')
         @schedules = schedules
-        @tracks = schedules.map { [_1.track_name, _1] }.to_h
+        @tracks = schedules.map { [_1.track.name, _1] }.to_h
         @sort_key = schedules[0].start_at
       end
     end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,0 +1,6 @@
+class Track < ApplicationRecord
+  belongs_to :event
+
+  validates :name, presence: true
+  validates :position, presence: true
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,5 +1,6 @@
 class Track < ApplicationRecord
   belongs_to :event
+  has_many :schedules
 
   validates :name, presence: true
   validates :position, presence: true

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Track < ApplicationRecord
   belongs_to :event
   has_many :schedules

--- a/app/models/validators/event_equality_validator.rb
+++ b/app/models/validators/event_equality_validator.rb
@@ -6,15 +6,26 @@ module Validators
 
     def validate(record)
       RELATIONS.inject(nil) do |acc, relation|
-        next acc unless record.respond_to?(relation) && record.send(relation)&.event_id
+        next acc unless record.respond_to?(relation)
 
-        acc ||= record.send(relation).event_id
+        event_id = find_event_id(record.send(relation))
 
-        if acc && acc != record.send(relation).event_id
-          record.errors.add relation, 'Event id must be same in cross relations.'
-        end
+        next acc unless event_id
+        next event_id unless acc
+
+        record.errors.add relation, 'Event id must be same in cross relations.' if acc != event_id
 
         acc
+      end
+    end
+
+    private
+
+    def find_event_id(relation)
+      if relation.respond_to?(:event_id)
+        relation.event_id
+      elsif relation.respond_to?(:track)
+        relation.track.event.id
       end
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500&family=Roboto:wght@400;500&display=auto" rel="stylesheet">
 
     <meta name="turbo-visit-control" content="reload">
+    <% if Rails.env.test? %>
+      <%= tag :meta, name: :rails_env, content: Rails.env %>
+    <% end %>
     <%= yield(:head) %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>

--- a/app/views/schedules/_card.html.erb
+++ b/app/views/schedules/_card.html.erb
@@ -13,7 +13,7 @@
             <span class="text-[rgb(112,109,101)]">Lang: </span><span class="ml-2"><%= schedule.language %></span>
           </div>
           <div class="flex flex-row justify-center items-center px-3 mr-2 h-6 bg-[rgb(248,247,246)] border border-solid border-[rgb(214,211,208)] box-border rounded-[100px] text-sm text-[rgb(35,34,31)]">
-            <span class="text-[rgb(112,109,101)]">Track: </span><span class="ml-2"><%= schedule.track_name %></span>
+            <span class="text-[rgb(112,109,101)]">Track: </span><span class="ml-2"><%= schedule.track.name %></span>
           </div>
         </div>
       </div>

--- a/db/migrate/20240404161019_create_tracks.rb
+++ b/db/migrate/20240404161019_create_tracks.rb
@@ -1,0 +1,13 @@
+class CreateTracks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tracks, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+      t.references :event, type: :uuid, null: false, foreign_key: true
+      t.string :name, null: false
+      t.integer :position, null: false, default: 1
+
+      t.timestamps
+    end
+
+    add_index :tracks, [:event_id, :name], unique: true
+  end
+end

--- a/db/migrate/20240404161858_convert_schedules_track.rb
+++ b/db/migrate/20240404161858_convert_schedules_track.rb
@@ -1,0 +1,34 @@
+class ConvertSchedulesTrack < ActiveRecord::Migration[7.1]
+  def up
+    add_column :schedules, :track_id, :uuid
+
+    Schedule.all.each do |schedule|
+      track = Track.find_or_create_by!(event: schedule.event, name: schedule.track_name)
+      schedule.track = track
+      schedule.save!
+    end
+    
+    Event.all.each do |event|
+      event.tracks.sort_by { _1.name.reverse }.each_with_index do |track, i|
+        track.position = i + 1
+        track.save!
+      end
+    end
+
+    remove_column :schedules, :track_name
+    change_column :schedules, :track_id, :uuid, null: false
+    add_foreign_key :schedules, :tracks
+  end
+
+  def down
+    add_column :schedules, :track_name, :string
+    
+    Schedule.all.each do |schedule|
+      schedule.track_name = schedule.track.name
+      schedule.save!
+    end
+
+    change_column :schedules, :track_name, :string, null: false
+    remove_column :schedules, :track_id
+  end
+end

--- a/db/migrate/20240405044111_schedule_belongs_track.rb
+++ b/db/migrate/20240405044111_schedule_belongs_track.rb
@@ -1,0 +1,15 @@
+class ScheduleBelongsTrack < ActiveRecord::Migration[7.1]
+  def up
+    remove_column :schedules, :event_id
+  end
+
+  def down
+    add_column :schedules, :event_id, :uuid
+
+    Schedule.all.each do |schedule|
+      schedule.update!(event: schedule.track.event)
+    end
+
+    change_column :schedules, :event_id, :uuid, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_04_145148) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_04_161019) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -96,10 +96,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_145148) do
     t.uuid "event_id", null: false
   end
 
+  create_table "tracks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "event_id", null: false
+    t.string "name", null: false
+    t.integer "position", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id", "name"], name: "index_tracks_on_event_id_and_name", unique: true
+    t.index ["event_id"], name: "index_tracks_on_event_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   add_foreign_key "profiles", "users"
+  add_foreign_key "tracks", "events"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_04_161019) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_04_161858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -79,9 +79,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_161019) do
     t.datetime "end_at", precision: nil, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "track_name", null: false
     t.integer "language", default: 0, null: false
     t.uuid "event_id", null: false
+    t.uuid "track_id", null: false
   end
 
   create_table "speakers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -112,5 +112,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_161019) do
   end
 
   add_foreign_key "profiles", "users"
+  add_foreign_key "schedules", "tracks"
   add_foreign_key "tracks", "events"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_04_161858) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_05_044111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -80,7 +80,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_161858) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "language", default: 0, null: false
-    t.uuid "event_id", null: false
     t.uuid "track_id", null: false
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,8 +60,7 @@ ActiveRecord::Base.transaction do
           schedule.update!(
             track: track,
             start_at: start_at,
-            end_at: end_at,
-            event: base_event
+            end_at: end_at
           )
           end
         end
@@ -82,8 +81,7 @@ ActiveRecord::Base.transaction do
             hash[id] = Schedule.find_or_initialize_by(
               track: track,
               start_at: start_at,
-              end_at: end_at,
-              event: base_event
+              end_at: end_at
             )
           end
         else
@@ -92,8 +90,7 @@ ActiveRecord::Base.transaction do
             hash[id] = Schedule.find_or_initialize_by(
               track: track,
               start_at: start_at,
-              end_at: end_at,
-              event: base_event
+              end_at: end_at
             )
           end
         end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,9 +56,9 @@ ActiveRecord::Base.transaction do
           next # LTのデータが埋まったら対応する
         else
           event['talks'].each do |track_name, id| schedule = schedules_by_id[id]
-
+          track = Track.find_or_create_by!(event: base_event, name: "Track#{track_name}")
           schedule.update!(
-            track_name: "Track#{track_name}",
+            track: track,
             start_at: start_at,
             end_at: end_at,
             event: base_event
@@ -78,8 +78,9 @@ ActiveRecord::Base.transaction do
           next
         when 'lt'
           event['talks'].each do |track_name, id|
+            track = Track.find_or_create_by!(event: base_event, name: "Track#{track_name}")
             hash[id] = Schedule.find_or_initialize_by(
-              track_name: "Track#{track_name}",
+              track: track,
               start_at: start_at,
               end_at: end_at,
               event: base_event
@@ -87,8 +88,9 @@ ActiveRecord::Base.transaction do
           end
         else
           event['talks'].each do |track_name, id|
+            track = Track.find_or_create_by!(event: base_event, name: "Track#{track_name}")
             hash[id] = Schedule.find_or_initialize_by(
-              track_name: "Track#{track_name}",
+              track: track,
               start_at: start_at,
               end_at: end_at,
               event: base_event

--- a/test/fixtures/schedules.yml
+++ b/test/fixtures/schedules.yml
@@ -7,7 +7,6 @@ one:
   end_at: 2021-07-20 10:40:00
   track: party_track_a
   language: 0
-  event: party
 
 two:
   title: "Schedule title 2"
@@ -16,7 +15,6 @@ two:
   end_at: 2021-07-20 11:40:00
   track: party_track_b
   language: 0
-  event: party
 
 three:
   title: "Schedule title 3"
@@ -25,7 +23,6 @@ three:
   end_at: 2021-07-21 10:40:00
   track: party_track_a
   language: 1
-  event: party
 
 four:
   title: "Schedule title 4"
@@ -34,7 +31,6 @@ four:
   end_at: 2021-07-21 11:40:00
   track: party_track_b
   language: 1
-  event: party
 
 five:
   title: "Schedule title 5"
@@ -43,7 +39,6 @@ five:
   end_at: 2021-07-21 11:40:00
   track: party_track_c
   language: 1
-  event: party
 
 dojo_one:
   title: "Schedule title 1 in Dojo"
@@ -52,7 +47,6 @@ dojo_one:
   end_at: 2023-01-01 10:40:00
   track: dojo_track_a
   language: 0
-  event: dojo
 
 kaigi_day1_time1_track1:
   title: "keynote1"
@@ -61,7 +55,6 @@ kaigi_day1_time1_track1:
   end_at: 2024-3-18 10:30:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day1_time2_track1:
   title: "session1-1-1"
@@ -70,7 +63,6 @@ kaigi_day1_time2_track1:
   end_at: 2024-3-18 11:00:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day1_time2_track2:
   title: "session1-1-2"
@@ -79,7 +71,6 @@ kaigi_day1_time2_track2:
   end_at: 2024-3-18 11:00:00
   track: kaigi_track_b
   language: 0
-  event: kaigi
 
 kaigi_day1_time2_track3:
   title: "session1-1-3"
@@ -88,7 +79,6 @@ kaigi_day1_time2_track3:
   end_at: 2024-3-18 11:00:00
   track: kaigi_track_c
   language: 0
-  event: kaigi
 
 kaigi_day1_time3_track1:
   title: "session1-2-1"
@@ -97,7 +87,6 @@ kaigi_day1_time3_track1:
   end_at: 2024-3-18 11:30:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day1_time3_track2:
   title: "session1-2-2"
@@ -106,7 +95,6 @@ kaigi_day1_time3_track2:
   end_at: 2024-3-18 11:30:00
   track: kaigi_track_b
   language: 0
-  event: kaigi
 
 kaigi_day1_time4_track1:
   title: "session1-3"
@@ -115,7 +103,6 @@ kaigi_day1_time4_track1:
   end_at: 2024-3-18 12:30:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day2_time1_track1:
   title: "session2-1-1"
@@ -124,7 +111,6 @@ kaigi_day2_time1_track1:
   end_at: 2024-3-19 09:30:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day2_time1_track2:
   title: "session2-1-2"
@@ -133,7 +119,6 @@ kaigi_day2_time1_track2:
   end_at: 2024-3-19 09:30:00
   track: kaigi_track_b
   language: 0
-  event: kaigi
 
 kaigi_day2_time1_track3:
   title: "session2-1-3"
@@ -142,7 +127,6 @@ kaigi_day2_time1_track3:
   end_at: 2024-3-19 09:30:00
   track: kaigi_track_c
   language: 0
-  event: kaigi
 
 kaigi_day2_time2_track1:
   title: "session2-2-1"
@@ -151,7 +135,6 @@ kaigi_day2_time2_track1:
   end_at: 2024-3-19 10:30:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day2_time2_track2:
   title: "session2-2-2"
@@ -160,7 +143,6 @@ kaigi_day2_time2_track2:
   end_at: 2024-3-19 10:30:00
   track: kaigi_track_b
   language: 0
-  event: kaigi
 
 kaigi_day2_time3_track1:
   title: "session2-3-1"
@@ -169,7 +151,6 @@ kaigi_day2_time3_track1:
   end_at: 2024-3-19 11:10:00
   track: kaigi_track_a
   language: 0
-  event: kaigi
 
 kaigi_day2_time3_track2:
   title: "session2-3-2"
@@ -178,7 +159,6 @@ kaigi_day2_time3_track2:
   end_at: 2024-3-19 11:10:00
   track: kaigi_track_b
   language: 0
-  event: kaigi
 
 kaigi_day2_time4_track1:
   title: "keynote2"
@@ -187,4 +167,3 @@ kaigi_day2_time4_track1:
   end_at: 2024-3-19 14:00:00
   track: kaigi_track_a
   language: 0
-  event: kaigi

--- a/test/fixtures/schedules.yml
+++ b/test/fixtures/schedules.yml
@@ -5,7 +5,7 @@ one:
   description: "This is Schedule title 1 description"
   start_at: 2021-07-20 10:00:00
   end_at: 2021-07-20 10:40:00
-  track_name: TrackA
+  track: party_track_a
   language: 0
   event: party
 
@@ -14,7 +14,7 @@ two:
   description: "This is Schedule title 2 description"
   start_at: 2021-07-20 11:00:00
   end_at: 2021-07-20 11:40:00
-  track_name: TrackB
+  track: party_track_b
   language: 0
   event: party
 
@@ -23,7 +23,7 @@ three:
   description: "This is Schedule title 3 description"
   start_at: 2021-07-21 10:00:00
   end_at: 2021-07-21 10:40:00
-  track_name: TrackA
+  track: party_track_a
   language: 1
   event: party
 
@@ -32,7 +32,7 @@ four:
   description: "This is Schedule title 4 description"
   start_at: 2021-07-21 11:00:00
   end_at: 2021-07-21 11:40:00
-  track_name: TrackB
+  track: party_track_b
   language: 1
   event: party
 
@@ -41,7 +41,7 @@ five:
   description: "This is Schedule title 5 description"
   start_at: 2021-07-21 11:00:00
   end_at: 2021-07-21 11:40:00
-  track_name: TrackC
+  track: party_track_c
   language: 1
   event: party
 
@@ -50,7 +50,7 @@ dojo_one:
   description: "This is Schedule title 1 in Dojo description"
   start_at: 2022-12-31 10:00:00
   end_at: 2023-01-01 10:40:00
-  track_name: TrackA
+  track: dojo_track_a
   language: 0
   event: dojo
 
@@ -59,7 +59,7 @@ kaigi_day1_time1_track1:
   description: "keynote1"
   start_at: 2024-3-18 10:00:00
   end_at: 2024-3-18 10:30:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -68,7 +68,7 @@ kaigi_day1_time2_track1:
   description: "session1-1"
   start_at: 2024-3-18 10:40:00
   end_at: 2024-3-18 11:00:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -77,7 +77,7 @@ kaigi_day1_time2_track2:
   description: "session1-2"
   start_at: 2024-3-18 10:40:00
   end_at: 2024-3-18 11:00:00
-  track_name: TrackB
+  track: kaigi_track_b
   language: 0
   event: kaigi
 
@@ -86,7 +86,7 @@ kaigi_day1_time2_track3:
   description: "session1-1-3"
   start_at: 2024-3-18 10:40:00
   end_at: 2024-3-18 11:00:00
-  track_name: TrackC
+  track: kaigi_track_c
   language: 0
   event: kaigi
 
@@ -95,7 +95,7 @@ kaigi_day1_time3_track1:
   description: "session2-1"
   start_at: 2024-3-18 11:10:00
   end_at: 2024-3-18 11:30:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -104,7 +104,7 @@ kaigi_day1_time3_track2:
   description: "session2-2"
   start_at: 2024-3-18 11:10:00
   end_at: 2024-3-18 11:30:00
-  track_name: TrackB
+  track: kaigi_track_b
   language: 0
   event: kaigi
 
@@ -113,7 +113,7 @@ kaigi_day1_time4_track1:
   description: "session3"
   start_at: 2024-3-18 11:45:00
   end_at: 2024-3-18 12:30:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -122,7 +122,7 @@ kaigi_day2_time1_track1:
   description: "session2-1-1"
   start_at: 2024-3-19 09:00:00
   end_at: 2024-3-19 09:30:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -131,7 +131,7 @@ kaigi_day2_time1_track2:
   description: "session2-1-2"
   start_at: 2024-3-19 09:00:00
   end_at: 2024-3-19 09:30:00
-  track_name: TrackB
+  track: kaigi_track_b
   language: 0
   event: kaigi
 
@@ -140,7 +140,7 @@ kaigi_day2_time1_track3:
   description: "session2-1-3"
   start_at: 2024-3-19 09:00:00
   end_at: 2024-3-19 09:30:00
-  track_name: TrackC
+  track: kaigi_track_c
   language: 0
   event: kaigi
 
@@ -149,7 +149,7 @@ kaigi_day2_time2_track1:
   description: "session2-2-1"
   start_at: 2024-3-19 10:00:00
   end_at: 2024-3-19 10:30:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -158,7 +158,7 @@ kaigi_day2_time2_track2:
   description: "session2-2-2"
   start_at: 2024-3-19 10:00:00
   end_at: 2024-3-19 10:30:00
-  track_name: TrackB
+  track: kaigi_track_b
   language: 0
   event: kaigi
 
@@ -167,7 +167,7 @@ kaigi_day2_time3_track1:
   description: "session2-3-1"
   start_at: 2024-3-19 10:40:00
   end_at: 2024-3-19 11:10:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi
 
@@ -176,7 +176,7 @@ kaigi_day2_time3_track2:
   description: "session2-3-2"
   start_at: 2024-3-19 10:40:00
   end_at: 2024-3-19 11:10:00
-  track_name: TrackB
+  track: kaigi_track_b
   language: 0
   event: kaigi
 
@@ -185,6 +185,6 @@ kaigi_day2_time4_track1:
   description: "keynote2"
   start_at: 2024-3-19 13:00:00
   end_at: 2024-3-19 14:00:00
-  track_name: TrackA
+  track: kaigi_track_a
   language: 0
   event: kaigi

--- a/test/fixtures/tracks.yml
+++ b/test/fixtures/tracks.yml
@@ -1,0 +1,37 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+party_track_a:
+  event: party
+  name: TrackA
+  position: 1
+
+party_track_b:
+  event: party
+  name: TrackB
+  position: 2
+
+party_track_c:
+  event: party
+  name: TrackC
+  position: 3
+
+dojo_track_a:
+  event: dojo
+  name: TrackA
+  position: 1
+
+kaigi_track_a:
+  event: kaigi
+  name: TrackA
+  position: 1
+
+kaigi_track_b:
+  event: kaigi
+  name: TrackB
+  position: 2
+
+kaigi_track_c:
+  event: kaigi
+  name: TrackC
+  position: 3
+

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -62,7 +62,7 @@ class PlanTest < ActiveSupport::TestCase
     johnny, kerry = speakers(:johnny, :kerry)
     left = Schedule.create!(
       title: 'test1',
-      track_name: 'test track',
+      track: tracks(:party_track_a),
       speakers: [johnny],
       start_at: Time.zone.parse('2021-07-30 12:00:00'),
       end_at: Time.zone.parse('2021-07-30 13:00:00'),
@@ -70,7 +70,7 @@ class PlanTest < ActiveSupport::TestCase
     )
     right = Schedule.create!(
       title: 'test2',
-      track_name: 'test track',
+      track: tracks(:party_track_b),
       speakers: [kerry],
       start_at: Time.zone.parse('2021-07-30 12:30:00'),
       end_at: Time.zone.parse('2021-07-30 13:20:00'),
@@ -87,7 +87,7 @@ class PlanTest < ActiveSupport::TestCase
     johnny, kerry = speakers(:johnny, :kerry)
     left = Schedule.create!(
       title: 'test1',
-      track_name: 'test track',
+      track: tracks(:party_track_a),
       speakers: [johnny],
       start_at: Time.zone.parse('2021-07-30 12:00:00'),
       end_at: Time.zone.parse('2021-07-30 13:00:00'),
@@ -95,7 +95,7 @@ class PlanTest < ActiveSupport::TestCase
     )
     right = Schedule.create!(
       title: 'test2',
-      track_name: 'test track',
+      track: tracks(:party_track_a),
       speakers: [kerry],
       start_at: Time.zone.parse('2021-07-30 13:00:00'),
       end_at: Time.zone.parse('2021-07-30 14:00:00'),

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -65,16 +65,14 @@ class PlanTest < ActiveSupport::TestCase
       track: tracks(:party_track_a),
       speakers: [johnny],
       start_at: Time.zone.parse('2021-07-30 12:00:00'),
-      end_at: Time.zone.parse('2021-07-30 13:00:00'),
-      event: events(:party)
+      end_at: Time.zone.parse('2021-07-30 13:00:00')
     )
     right = Schedule.create!(
       title: 'test2',
       track: tracks(:party_track_b),
       speakers: [kerry],
       start_at: Time.zone.parse('2021-07-30 12:30:00'),
-      end_at: Time.zone.parse('2021-07-30 13:20:00'),
-      event: events(:party)
+      end_at: Time.zone.parse('2021-07-30 13:20:00')
     )
 
     p = Plan.create!(title: 'test', user: User.create!, event: events(:party))
@@ -90,16 +88,14 @@ class PlanTest < ActiveSupport::TestCase
       track: tracks(:party_track_a),
       speakers: [johnny],
       start_at: Time.zone.parse('2021-07-30 12:00:00'),
-      end_at: Time.zone.parse('2021-07-30 13:00:00'),
-      event: events(:party)
+      end_at: Time.zone.parse('2021-07-30 13:00:00')
     )
     right = Schedule.create!(
       title: 'test2',
       track: tracks(:party_track_a),
       speakers: [kerry],
       start_at: Time.zone.parse('2021-07-30 13:00:00'),
-      end_at: Time.zone.parse('2021-07-30 14:00:00'),
-      event: events(:party)
+      end_at: Time.zone.parse('2021-07-30 14:00:00')
     )
 
     p = Plan.create!(title: 'test', user: User.create!, event: events(:party))

--- a/test/models/schedule/table/row_test.rb
+++ b/test/models/schedule/table/row_test.rb
@@ -6,7 +6,7 @@ class Schedule
   class Table
     class RowTest < ActiveSupport::TestCase
       def setup
-        schedules = Schedule.where(event: events(:kaigi))
+        schedules = events(:kaigi).schedules
         @tables = Schedule::Tables.new(schedules)
       end
 

--- a/test/models/schedule/table_test.rb
+++ b/test/models/schedule/table_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Schedule
   class TableTest < ActiveSupport::TestCase
     def setup
-      schedules = Schedule.where(event: events(:kaigi))
+      schedules = events(:kaigi).schedules
       tables = Schedule::Tables.new(schedules)
       @table = tables[tables.days.first]
     end

--- a/test/models/schedule/table_test.rb
+++ b/test/models/schedule/table_test.rb
@@ -21,5 +21,36 @@ class Schedule
     test '#rows returns array sorted by track start time' do
       assert_equal @table.rows.map { _1.tracks['TrackA'] }, @table.rows.map { _1.tracks['TrackA'] }.sort_by(&:start_at)
     end
+
+    test '#track_list returns track names sorted by Track#position' do
+      event = Event.build(name: 'track_sort_test')
+      event.build_event_theme(
+        main_color: '#0B374D',
+        sub_color: '#EBE0CE',
+        accent_color: '#D7D165',
+        text_color: '#23221F',
+        overview: 'hoge',
+        site_label: 'foo',
+        site_url: 'https://example.com'
+      )
+      event.save!
+      track_a = event.tracks.create!(name: 'A', position: 2)
+      track_b = event.tracks.create!(name: 'B', position: 1)
+      speaker = event.speakers.create!(name: 'kinoppyd', handle: 'ppyd', profile: 'wooo', thumbnail: 'https://example.com')
+
+      schedule_a = track_a.schedules.create!(title: 'test1', speakers: [speaker], start_at: '2024-04-06 01:50', end_at: '2024-04-06 01:55')
+      schedule_b = track_b.schedules.create!(title: 'test2', speakers: [speaker], start_at: '2024-04-06 01:50', end_at: '2024-04-06 01:55')
+
+      table = Schedule::Table.new([schedule_a, schedule_b])
+
+      assert_equal %w[B A], table.track_list
+
+      track_a.update!(position: 1)
+      track_b.update!(position: 2)
+
+      table = Schedule::Table.new([schedule_a, schedule_b])
+
+      assert_equal %w[A B], table.track_list
+    end
   end
 end

--- a/test/models/schedule/table_test.rb
+++ b/test/models/schedule/table_test.rb
@@ -38,8 +38,10 @@ class Schedule
       track_b = event.tracks.create!(name: 'B', position: 1)
       speaker = event.speakers.create!(name: 'kinoppyd', handle: 'ppyd', profile: 'wooo', thumbnail: 'https://example.com')
 
-      schedule_a = track_a.schedules.create!(title: 'test1', speakers: [speaker], start_at: '2024-04-06 01:50', end_at: '2024-04-06 01:55')
-      schedule_b = track_b.schedules.create!(title: 'test2', speakers: [speaker], start_at: '2024-04-06 01:50', end_at: '2024-04-06 01:55')
+      schedule_a = track_a.schedules.create!(title: 'test1', speakers: [speaker], start_at: '2024-04-06 01:50',
+                                             end_at: '2024-04-06 01:55')
+      schedule_b = track_b.schedules.create!(title: 'test2', speakers: [speaker], start_at: '2024-04-06 01:50',
+                                             end_at: '2024-04-06 01:55')
 
       table = Schedule::Table.new([schedule_a, schedule_b])
 

--- a/test/models/schedule/tables_test.rb
+++ b/test/models/schedule/tables_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class Schedule
   class TablesTest < ActiveSupport::TestCase
     def setup
-      schedules = Schedule.where(event: events(:kaigi))
+      schedules = events(:kaigi).schedules
       @tables = Schedule::Tables.new(schedules)
     end
 

--- a/test/models/schedule_test.rb
+++ b/test/models/schedule_test.rb
@@ -38,22 +38,6 @@ class ScheduleTest < ActiveSupport::TestCase
     assert_not s.valid?
   end
 
-  test 'track name must greater than 0, less than 32' do
-    s = schedules(:one)
-
-    s.track_name = ''
-    assert_not s.valid?
-
-    s.track_name = 'TrackA'
-    assert s.valid?
-
-    s.track_name = 'あ' * 32
-    assert s.valid?
-
-    s.track_name = 'い' * 33
-    assert_not s.valid?
-  end
-
   test 'language must be presented' do
     s = schedules(:one)
 

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TrackTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class TrackTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
既存のScheduleモデルでは、track_nameを文字列として保持しているため、ソートのロジックが文字列ソートになる。
文字列では対応できないソートも存在するため、新たにTackモデルを作成し、positionを設定することでソートを可能にした。