### PR TITLE
TOPページのモバイル表示時のUIを改善

### DIFF
--- a/app/views/static/top.html.erb
+++ b/app/views/static/top.html.erb
@@ -7,7 +7,7 @@
   <meta name="twitter:card" content="summary_large_image"/>
 <% end %>
 
-<div class="pt-20 pl-36 flex flex-col gap-4">
+<div class="sm:pt-20 sm:pl-36 flex flex-col gap-4">
   <div class="text-[var(--textColor)] text-2xl">
     <div>
       <img src="<%= asset_path("#{@event.name}/title.svg") %>" />
@@ -21,7 +21,7 @@
     <div class="w-28 h-1 bg-[var(--subColor)]"></div>
     <div class="w-28 h-1 bg-[var(--accentColor)]"></div>
   </div>
-  <div class="w-[600px] break-keep my-6 text-[var(--textColor)] text-base leading-[200%]">
+  <div class="sm:w-[600px] my-6 text-[var(--textColor)] text-base leading-[200%]">
       <%= I18n.t('application.intro') %>
   </div>
   <div class="mb-4">


### PR DESCRIPTION
TOPページをスマホサイズで表示した時にコンテンツが見きれないようにしました。
ヘッダーやタブUIなどの共通部分は別途対応予定です。

### before

![image](https://github.com/kufu/mie/assets/53547520/a5662489-4ff8-4ca5-a223-70ac63f96030)


### after

![image](https://github.com/kufu/mie/assets/53547520/4dbc4d02-cd71-4b15-8113-6662a1de8f17)
