### PR TITLE
エラーページを表示できるようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,12 +27,18 @@ class ApplicationController < ActionController::Base
   def not_found(err)
     print_error_if_test(err)
     Rails.logger.debug("#{err}\n#{err.backtrace.join("\n")}")
+    @event = Event.find_by!(name: '2024')
+    set_user
+    set_plan
     render template: 'errors/not_found', status: 404, layout: 'application', content_type: 'text/html'
   end
 
   def server_error(err)
     print_error_if_test(err)
     Rails.logger.error("#{err}\n#{err.backtrace.join("\n")}")
+    @event = Event.find_by!(name: '2024')
+    set_user
+    set_plan
     render template: 'errors/server_error', status: 500, layout: 'application', content_type: 'text/html'
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,12 +27,16 @@ class ApplicationController < ActionController::Base
   def not_found(err)
     print_error_if_test(err)
     Rails.logger.debug("#{err}\n#{err.backtrace.join("\n")}")
+    set_default_event
+    set_plan
     render template: 'errors/not_found', status: 404, layout: 'application', content_type: 'text/html'
   end
 
   def server_error(err)
     print_error_if_test(err)
     Rails.logger.error("#{err}\n#{err.backtrace.join("\n")}")
+    set_default_event
+    set_plan
     render template: 'errors/server_error', status: 500, layout: 'application', content_type: 'text/html'
   end
 
@@ -75,5 +79,10 @@ class ApplicationController < ActionController::Base
     pp params
     puts err.message
     puts err.backtrace.join("\n")
+  end
+
+  def set_default_event
+    @event = Event.all.order(created_at: :desc).first
+    request.path_parameters[:event_name] = @event.name
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,18 +27,12 @@ class ApplicationController < ActionController::Base
   def not_found(err)
     print_error_if_test(err)
     Rails.logger.debug("#{err}\n#{err.backtrace.join("\n")}")
-    @event = Event.find_by!(name: '2024')
-    set_user
-    set_plan
     render template: 'errors/not_found', status: 404, layout: 'application', content_type: 'text/html'
   end
 
   def server_error(err)
     print_error_if_test(err)
     Rails.logger.error("#{err}\n#{err.backtrace.join("\n")}")
-    @event = Event.find_by!(name: '2024')
-    set_user
-    set_plan
     render template: 'errors/server_error', status: 500, layout: 'application', content_type: 'text/html'
   end
 


### PR DESCRIPTION
500エラーになった場合に、`errors/server_error.html.erb` に遷移するが、その画面でさらに以下画像のようなエラーになってしまい、エラーページが表示できていなかったので表示できるようにしました。
（Not Foundも同様）
<img width="1203" alt="スクリーンショット 2024-04-04 19 28 36" src="https://github.com/kufu/mie/assets/49850014/ef006d71-dd51-42b0-a263-5b5a8968d094">
<img width="1016" alt="スクリーンショット 2024-04-10 11 20 56" src="https://github.com/kufu/mie/assets/49850014/89535521-968f-499e-962b-137117024490">

修正後のエラーページ
|404|500|
|--|--|
|<img width="1919" alt="スクリーンショット 2024-04-12 19 20 19" src="https://github.com/kufu/mie/assets/49850014/6ffd1172-6850-42ac-8637-0c7fb1ae18a8">|<img width="1919" alt="スクリーンショット 2024-04-12 19 20 11" src="https://github.com/kufu/mie/assets/49850014/9a309952-aac7-43af-a513-e7ffd6fb9e88">|
