### PR TITLE
Enable ActionCable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require_relative 'boot'
 require 'rails'
 # Pick the frameworks you want:
 require 'active_model/railtie'
-# require "active_job/railtie"
+require 'active_job/railtie'
 require 'active_record/railtie'
 # require "active_storage/engine"
 require 'action_controller/railtie'

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ require 'action_controller/railtie'
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require 'action_view/railtie'
-# require "action_cable/engine"
+require "action_cable/engine"
 require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ require 'action_controller/railtie'
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require 'action_view/railtie'
-require "action_cable/engine"
+require 'action_cable/engine'
 require 'rails/test_unit/railtie'
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: async
+
+test:
+  adapter: test
+
+productrion:
+  adapter: async # for dummy, currently ActionCable is not used


### PR DESCRIPTION
To avoid this problem [Can't load turbo-rails without Action Cable starting in Rails 7.1.2 · Issue #512 · hotwired/turbo-rails](https://github.com/hotwired/turbo-rails/issues/512)