### PR TITLE
Fix track migration

### DIFF
--- a/db/migrate/20240404161858_convert_schedules_track.rb
+++ b/db/migrate/20240404161858_convert_schedules_track.rb
@@ -2,12 +2,18 @@ class ConvertSchedulesTrack < ActiveRecord::Migration[7.1]
   def up
     add_column :schedules, :track_id, :uuid
 
-    Schedule.all.each do |schedule|
-      track = Track.find_or_create_by!(event: schedule.event, name: schedule.track_name)
-      schedule.track = track
-      schedule.save!
+    #Schedule.all.each do |schedule|
+    #  track = Track.find_or_create_by!(event: schedule.event, name: schedule.track_name)
+    #  schedule.track = track
+    #  schedule.save!
+    #end
+    # Migrationを適用する前にモデルが大きく変化してしまい、元のインターフェイスが無いので、生クエリで実行
+    schedules = ActiveRecord::Base.connection.execute('SELECT * FROM schedules')
+    schedules.each do |schedule|
+      track = Track.find_or_create_by!(event: Event.find(schedule['event_id']), name: schedule['track_name'])
+      Schedule.find(schedule['id']).update!(track:)
     end
-    
+
     Event.all.each do |event|
       event.tracks.sort_by { _1.name.reverse }.each_with_index do |track, i|
         track.position = i + 1


### PR DESCRIPTION
This migration should apply step by step, but many behind commits there and changes Schedule model I/F and validations.
To avoid error, don't use Schedule model and execute raw queries result object to create Track records.