### PR TITLE
[QA:32] Hide invitation role plan

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -9,4 +9,8 @@ class Team < ApplicationRecord
   def admin?(user)
     !!user.profile.team_profiles.find_by(team: self)&.admin?
   end
+
+  def active_profiles
+    profiles.where(team_profiles: { role: %i[admin member] })
+  end
 end

--- a/app/views/schedules/_card.html.erb
+++ b/app/views/schedules/_card.html.erb
@@ -39,7 +39,7 @@
 
         <% if mode == :team %>
           <div class="flex flex-wrap gap-2">
-            <% @team.profiles.each do |profile| %>
+            <% @team.active_profiles.each do |profile| %>
               <% if @member_schedules_map[profile.id].include?(schedule.id) %>
                 <img src="<%= profile.avatar_url %>" class="h-12 w-12 rounded-full border-2 border-black" />
               <% end %>

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -44,4 +44,9 @@ class TeamTest < ActiveSupport::TestCase
   test '#admin? returns false when invitation user given' do
     assert_not teams(:alpha).admin?(users(:three))
   end
+
+  test '#active_profiles returns profiles without invitations' do
+    assert_equal teams(:alpha).active_profiles.order(id: :asc),
+                 [profiles(:profile_one), profiles(:profile_two), profiles(:profile_four)].sort_by(&:id)
+  end
 end


### PR DESCRIPTION
Show only admin or member plans on team page.