### PR TITLE
user未作成の状態で視聴予定をパスワード入力して編集できるようにする

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -29,6 +29,7 @@ class PlansController < ApplicationController
   end
 
   def editable
+    create_and_set_user unless @user
     if @plan.password == params[:password]
       @plan.update!(user: @user)
       redirect_to event_plan_path(@plan, event_name: @plan.event.name)


### PR DESCRIPTION
パスワードを入力しても視聴予定を編集できないバグの修正です。
user未作成（視聴予定未作成）の状態では、userが存在せずエラーになっていたので、userを作成するようにしました。

バグの再現手順:
1.ノートを公開にしてパスワードを設定する
2.別ブラウザでURLを開き（視聴予定未作成の状態）、パスワードを入力する
3.401エラーになる

期待する挙動:
3で401エラーにならずに編集できる