### PR TITLE
ogp画像の対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'turbo-rails', '~> 2.0'
 gem 'omniauth-github', '~> 2.0'
 gem 'omniauth-rails_csrf_protection', '~> 1.0'
 
-gem 'imgkit'
+gem 'imgkit', '~> 1.6.3'
 install_if -> { RUBY_PLATFORM =~ /darwin/ } do
   gem 'wkhtmltoimage-binary'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    imgkit (1.6.2)
+    imgkit (1.6.3)
     io-console (0.7.2)
     irb (1.12.0)
       rdoc
@@ -319,7 +319,7 @@ DEPENDENCIES
   capybara
   dotenv (~> 3.1)
   erb-formatter (~> 0.4.3)
-  imgkit
+  imgkit (~> 1.6.3)
   jsbundling-rails (~> 1.2)
   listen (~> 3.3)
   omniauth-github (~> 2.0)

--- a/app/controllers/plans/ogps_controller.rb
+++ b/app/controllers/plans/ogps_controller.rb
@@ -66,7 +66,8 @@ module Plans
     end
 
     def ogp_background_image
-      "data:image/png;base64,#{Base64.strict_encode64(File.read("app/assets/images/#{@event.name}/ogp.png", mode: 'rb'))}"
+      "data:image/png;base64,#{Base64.strict_encode64(File.read("app/assets/images/#{@event.name}/ogp.png",
+                                                                mode: 'rb'))}"
     end
   end
 end

--- a/app/controllers/plans/ogps_controller.rb
+++ b/app/controllers/plans/ogps_controller.rb
@@ -66,7 +66,7 @@ module Plans
     end
 
     def ogp_background_image
-      "data:image/png;base64,#{Base64.strict_encode64(File.read("public/#{@event.name}/ogp.png", mode: 'rb'))}"
+      "data:image/png;base64,#{Base64.strict_encode64(File.read("app/assets/images/#{@event.name}/ogp.png", mode: 'rb'))}"
     end
   end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,11 +1,3 @@
-<% content_for :head do %>
-  <meta property="og:title" content="RubyKaigi Schedule.select">
-  <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
-  <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image"/>
-<% end %>
-
 <div class="w-full h-[90vh] flex items-center justify-center">
   <div class="flex items-center justify-center w-[1120px] h-[275px]">
     <div class="h-28 w-28 bg-cover" style="background-image: url('<%= asset_path("#{@event.name}/rubykaigi.png") %>');"></div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,11 +1,3 @@
-<% content_for :head do %>
-  <meta property="og:title" content="RubyKaigi Schedule.select">
-  <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
-  <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image"/>
-<% end %>
-
 <div class="w-full h-[90vh] flex items-center justify-center">
   <div class="flex items-center justify-center w-[1120px] h-[275px]">
     <div class="h-28 w-28 bg-cover" style="background-image: url('<%= asset_path("#{@event.name}/rubykaigi.png") %>');"></div>

--- a/app/views/errors/server_error.html.erb
+++ b/app/views/errors/server_error.html.erb
@@ -1,11 +1,3 @@
-<% content_for :head do %>
-  <meta property="og:title" content="RubyKaigi Schedule.select">
-  <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
-  <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image"/>
-<% end %>
-
 <div class="w-full h-[90vh] flex items-center justify-center">
   <div class="flex items-center justify-center w-[1120px] h-[275px]">
     <div class="h-28 w-28 bg-cover" style="background-image: url('<%= asset_path("#{@event.name}/rubykaigi.png") %>');"></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,17 @@
     <% if Rails.env.test? %>
       <%= tag :meta, name: :rails_env, content: Rails.env %>
     <% end %>
+    
+    <meta property="og:title" content="RubyKaigi Schedule.select">
+    <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
+    <% unless Rails.env.test? %>
+      <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
+    <% end %>
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image"/>
+    
     <%= yield(:head) %>
+    
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,11 @@
     <meta property="og:title" content="RubyKaigi Schedule.select">
     <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
     <% unless Rails.env.test? %>
-      <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
+      <% if controller_name == 'plans' && action_name = 'show' && @plan %>
+        <meta property="og:image" content="<%= event_plan_ogp_url(@plan, event_name: @plan.event.name, h: Digest::MD5.hexdigest(@plan.description)) %>" />
+      <% else %>
+        <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
+      <% end %>
     <% end %>
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image"/>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,7 +1,9 @@
 
 <% content_for :head do %>
+  <%# TODO: descriptionが埋め込めていない %>
   <meta property="og:description" content="<%= @plan.description %>">
   <meta property="og:url" content="<%= event_plan_url(event_name: @plan.event.name) %>">
+  <%# TODO: application.html.erb で ogp:image が上書きされているので、上書きされないような仕組みを考える必要がある %>
   <meta property="og:image" content="<%= event_plan_ogp_url(@plan, event_name: @plan.event.name, h: Digest::MD5.hexdigest(@plan.description)) %>" />
 <% end %>
 
@@ -143,7 +145,8 @@
     <div class="flex justify-between items-end">
       <div class="flex flex-col gap-1">
         <h1 class="text-base"><%= I18n.t('description.title') %></h1>
-        <span class="text-sm text-[rgb(112,109,101)]"><%= I18n.t('description.notice') %></span>
+        <%# TODO: 動的ogpが直ったらコメントインする %>
+        <!-- <span class="text-sm text-[rgb(112,109,101)]"><%= I18n.t('description.notice') %></span> -->
       </div>
       <% if @plan.user == @user %>
         <div data-controller="dialog" data-dialog-element-id-value="edit-description-dialog">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,9 +1,7 @@
 
 <% content_for :head do %>
-  <%# TODO: descriptionが埋め込めていない %>
   <meta property="og:description" content="<%= @plan.description %>">
   <meta property="og:url" content="<%= event_plan_url(event_name: @plan.event.name) %>">
-  <%# TODO: application.html.erb で ogp:image が上書きされているので、上書きされないような仕組みを考える必要がある %>
   <meta property="og:image" content="<%= event_plan_ogp_url(@plan, event_name: @plan.event.name, h: Digest::MD5.hexdigest(@plan.description)) %>" />
 <% end %>
 
@@ -145,8 +143,7 @@
     <div class="flex justify-between items-end">
       <div class="flex flex-col gap-1">
         <h1 class="text-base"><%= I18n.t('description.title') %></h1>
-        <%# TODO: 動的ogpが直ったらコメントインする %>
-        <!-- <span class="text-sm text-[rgb(112,109,101)]"><%= I18n.t('description.notice') %></span> -->
+        <span class="text-sm text-[rgb(112,109,101)]"><%= I18n.t('description.notice') %></span>
       </div>
       <% if @plan.user == @user %>
         <div data-controller="dialog" data-dialog-element-id-value="edit-description-dialog">

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -2,7 +2,6 @@
 <% content_for :head do %>
   <meta property="og:description" content="<%= @plan.description %>">
   <meta property="og:url" content="<%= event_plan_url(event_name: @plan.event.name) %>">
-  <meta property="og:image" content="<%= event_plan_ogp_url(@plan, event_name: @plan.event.name, h: Digest::MD5.hexdigest(@plan.description)) %>" />
 <% end %>
 
 <%= turbo_frame_tag @plan do %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,12 +1,8 @@
 
 <% content_for :head do %>
-  <meta property="og:title" content="<%= @plan.title %>">
-  <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
   <meta property="og:description" content="<%= @plan.description %>">
   <meta property="og:url" content="<%= event_plan_url(event_name: @plan.event.name) %>">
   <meta property="og:image" content="<%= event_plan_ogp_url(@plan, event_name: @plan.event.name, h: Digest::MD5.hexdigest(@plan.description)) %>" />
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image"/>
 <% end %>
 
 <%= turbo_frame_tag @plan do %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta property="og:url" content="<%= profile_url %>">
+<% end %>
+
 <% if @breakout_turbo %>
   <% turbo_page_requires_reload %>
 <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,12 +1,5 @@
 <% content_for :head do %>
-  <meta property="og:title" content="RubyKaigi Schedule.select">
-  <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
   <meta property="og:url" content="<%= event_schedules_url(event_name: @event.name) %>">
-  <% unless Rails.env.test? %>
-    <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
-  <% end %>
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image"/>
 <% end %>
 
 <%= turbo_frame_tag @event, refresh: :morph do %>

--- a/app/views/static/top.html.erb
+++ b/app/views/static/top.html.erb
@@ -1,10 +1,5 @@
 <% content_for :head do %>
-  <meta property="og:title" content="RubyKaigi Schedule.select">
-  <meta property="og:site_name" content="RubyKaigi Schedule.select powerd by SmartHR">
   <meta property="og:url" content="<%= root_url + "#{@event.name}/" %>">
-  <meta property="og:image" content="<%= asset_url("#{@event.name}/ogp_top.png") %>" />
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image"/>
 <% end %>
 
 <div class="sm:pt-20 sm:pl-36 flex flex-col gap-4">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta property="og:url" content="<%= team_url(@team) %>">
+<% end %>
+
 <% if @breakout_turbo %>
   <% turbo_page_requires_reload %>
 <% end %>


### PR DESCRIPTION
ogp周りのmetaタグを共通化して、ひとまず全てのページでogp_top画像が表示されるようにしました。
視聴予定の動的ogpについては、途中まで対応したのですが、以下のエラーが発生して原因の究明に時間がかかりそうだったので諦めました。
```
undefined method `exists?' for class File
/Users/emine.ikuta/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/imgkit-1.6.2/lib/imgkit/imgkit.rb:45:in `initialize'
/Users/emine.ikuta/ghq/github.com/kufu/mie/app/controllers/plans/ogps_controller.rb:9:in `new'
```

視聴予定のUI上の、動的に埋め込みますよ、の文言は嘘になるので一旦コメントウトしています。