### PR TITLE
モバイル時のpaddingの幅を調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
     <header>
       <%= render 'layouts/header' %>
     </header>
-    <div class="p-2 sm:p-8">
+    <div class="p-4 sm:p-8">
       <%= yield %>
     </div>
   </body>


### PR DESCRIPTION
モバイル時のpaddingがヘッダーの左右の幅に比べて狭かったので揃える