### PR TITLE
モバイル時の日付切り替えタブの幅を調整し、横スクロールが出ないようにする

### DIFF
--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -103,9 +103,9 @@
     <% else %>
       <div data-controller="schedule-table" class="max-w-[1120px] mx-auto">
         <div class="flex overflow-x-auto overflow-y-hidden gap-2 p-0">
-          <div class="relative flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
+          <div class="relative flex sm:block justify-between flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
             <% @plans_table.keys.map do |k| %>
-              <button data-action="click->schedule-table#switch" value="<%= k %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
+              <button data-action="click->schedule-table#switch" value="<%= k %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-2 sm:px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
                 <%= k %>
               </button>
             <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -28,9 +28,9 @@
     </div>
   </label>
   <div class="flex overflow-x-auto overflow-y-hidden gap-2 p-0">
-    <div class="relative flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
+    <div class="relative flex sm:block justify-between flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
       <% @schedule_table.days.each do |day| %>
-        <button data-action="click->schedule-table#switch" value="<%= day %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
+        <button data-action="click->schedule-table#switch" value="<%= day %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-2 sm:px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
           <%= day %>
         </button>
       <% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -46,9 +46,9 @@
 
 <div data-controller="schedule-table" class="max-w-[1120px] mx-auto">
   <div class="flex overflow-x-auto overflow-y-hidden gap-2 p-0">
-    <div class="relative flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
+    <div class="relative flex sm:block justify-between flex-grow shrink-0 basis-auto m-1 before:absolute before:left-0 before:right-0 before:bottom-0 before:border-b-[1px]">
       <% @schedule_table.days.each do |day| %>
-        <button data-action="click->schedule-table#switch" value="<%= day %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
+        <button data-action="click->schedule-table#switch" value="<%= day %>" class="tab-button bg-transparent appearance-none font-bold font-base text-[rgb(112,109,101)] h-10 solid border-0 border-b-[3px] px-2 sm:px-6 box-border border-b-transparent hover:bg-[rgb(248,247,246)] hover:text-[rgb(35,34,30)]">
           <%= day %>
         </button>
       <% end %>


### PR DESCRIPTION
schedule画面やチーム画面の日付を切り替えるタブがモバイルサイズでは大きく横スクロールが出てしまうため、画面幅に合わせて表示されるようにした

### before

![image](https://github.com/kufu/mie/assets/53547520/aa614cb7-be05-40bb-9766-66377df86f1a)


### after

![image](https://github.com/kufu/mie/assets/53547520/df23246d-8de8-496c-b75a-db6f1182dba9)
