### PR TITLE
Redirect to profile page if user not logged in when login required

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,6 +50,13 @@ class ApplicationController < ActionController::Base
     request.path_parameters[:event_name] = @event.name
   end
 
+  def make_sure_user_logged_in
+    return if @user&.profile
+
+    session[:breakout_turbo] = true
+    redirect_to profile_path, flash: { error: I18n.t('errors.login_required') }
+  end
+
   def create_and_set_user
     @user = User.create!
     session[:user_id] = @user.id

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -3,6 +3,7 @@
 class MembersController < ApplicationController
   class NoPermissionError < StandardError; end
 
+  before_action :make_sure_user_logged_in
   before_action :set_team
   before_action :set_team_profile, except: :create
   before_action :define_error_variable

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -3,6 +3,7 @@
 class TeamsController < ApplicationController
   class InvalidStateError < StandardError; end
 
+  before_action :make_sure_user_logged_in
   before_action :set_team, only: %i[show edit update destroy]
   before_action :check_user_belongs_to_team, only: %i[show update destroy]
 

--- a/app/controllers/triggers_controller.rb
+++ b/app/controllers/triggers_controller.rb
@@ -2,20 +2,12 @@
 
 class TriggersController < ApplicationController
   prepend_before_action :set_default_event
-  before_action :make_sure_user_has_profile
+  before_action :make_sure_user_logged_in
 
   def show
     trigger = Trigger.find(params[:id])
     trigger.perform(@user.profile, params[:key])
 
     redirect_to profile_path
-  end
-
-  private
-
-  def make_sure_user_has_profile
-    return if @user&.profile
-
-    redirect_to profile_path, flash: { error: I18n.t('errors.login_required') }
   end
 end

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -7,9 +7,17 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     @team = teams(:alpha)
   end
 
-  test 'should get new' do
+  test 'should get new with session' do
+    omniauth_callback_uid(1234) # profile_one
+    get '/auth/github/callback'
+
     get new_team_url
     assert_response :success
+  end
+
+  test 'should not get new without session' do
+    get new_team_url
+    assert_redirected_to profile_path
   end
 
   test 'should create team and creator profile has admin role' do
@@ -36,6 +44,14 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
+  end
+
+  test 'should not create team and redirect to profile if no session' do
+    assert_no_changes -> { [Team.count, TeamProfile.count] } do
+      post teams_url, params: { team: { name: 'Charlie' } }
+    end
+
+    assert_redirected_to profile_path
   end
 
   test 'should return new page when create with invalid param' do
@@ -76,6 +92,11 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'should not show team if no session' do
+    get team_url(@team)
+    assert_redirected_to profile_path
+  end
+
   test 'should update team' do
     omniauth_callback_uid(1234) # profile_one
     get '/auth/github/callback'
@@ -90,6 +111,11 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
 
     patch team_url(@team), params: { team: { name: 'Delta' } }
     assert_response :forbidden
+  end
+
+  test 'should not update team if no session' do
+    patch team_url(@team), params: { team: { name: 'Delta' } }
+    assert_redirected_to profile_path
   end
 
   test 'should destroy team' do
@@ -112,5 +138,10 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :forbidden
+  end
+
+  test 'should not destroy team if no session' do
+    delete team_url(@team)
+    assert_redirected_to profile_path
   end
 end

--- a/test/controllers/triggers_controller_test.rb
+++ b/test/controllers/triggers_controller_test.rb
@@ -36,4 +36,12 @@ class TriggersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to profile_path
   end
+
+  test 'no triggered if no session' do
+    assert_no_difference -> { ProfileTrophy.count } do
+      get trigger_path(@trigger, key: 'testkey')
+    end
+
+    assert_redirected_to profile_path
+  end
 end


### PR DESCRIPTION
When pages that requires user login accessed by no profile user, redirect to Profile page and request login.