### PR TITLE
プロフィール編集ダイアログの入力エリアの領域を広げる

### DIFF
--- a/app/views/profiles/_dialog.html.erb
+++ b/app/views/profiles/_dialog.html.erb
@@ -5,8 +5,8 @@
         <p class="text-xl"><%= I18n.t('dialog.edit_introduce') %></p>
       </div>
       <div class="max-h-[calc(100vh-212px)] overflow-auto">
-        <div class="w-full sm:w-[656px] p-6">
-          <%= f.text_area :introduce, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
+        <div class="w-full p-6">
+          <%= f.text_area :introduce, class: "border opacity-100 h-72 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
           <div class="font-xs mt-2 text-[rgb(112,109,101)]">
             <span data-word-counter-target="counter"></span>/<%= profile_introduce_max_length %>
           </div>


### PR DESCRIPTION
入力エリアの領域が狭かったので広げました。

### pc

| before  | after   |
| --- | --- |
|  ![image](https://github.com/kufu/mie/assets/53547520/39b68152-883f-4e0a-bfd3-e88b517e6a93)  |  ![image](https://github.com/kufu/mie/assets/53547520/9c46524d-e399-44da-a1af-019898f0d9b1)  |

### mobile

| before  | after   |
| --- | --- |
| ![image](https://github.com/kufu/mie/assets/53547520/46d0d099-4864-4c70-b555-4a128f286da1) |  ![image](https://github.com/kufu/mie/assets/53547520/a63176c4-1c34-4bfd-aac4-a99478f6321c) |
