### PR TITLE
ダイアログの横幅に変な余白があるので幅調整

### DIFF
--- a/app/views/plans/_description_dialog.html.erb
+++ b/app/views/plans/_description_dialog.html.erb
@@ -6,7 +6,7 @@
         <p class="text-xl"><%= I18n.t('description.form_titme') %></p>
       </div>
       <div class="max-h-[calc(100vh-212px)] overflow-auto">
-        <div class="w-full sm:w-[656px] p-6">
+        <div class="w-full p-6">
           <%= f.text_area :description, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
           <div class="font-xs mt-2 text-[rgb(112,109,101)]">
             <span data-word-counter-target="counter"></span>/<%= plan_description_max_length %>

--- a/app/views/plans/_password_dialog.html.erb
+++ b/app/views/plans/_password_dialog.html.erb
@@ -5,7 +5,7 @@
       <p class="my-0 text-xl"><%= I18n.t('settings.title') %></p>
     </div>
     <div class="max-h-[calc(100vh-212px)] overflow-auto">
-      <div class="w-full sm:w-[656px] p-6 border-b border-[rgb(214,211,208)]">
+      <div class="w-full p-6 border-b border-[rgb(214,211,208)]">
         <div class="py-2 w-full">
           <div><%= f.label :password, I18n.t('dialog.input_password'), class: "text-[rgb(112,109,101)] font-bold" %></div>
           <div class="mt-4">

--- a/app/views/plans/_rename_dialog.html.erb
+++ b/app/views/plans/_rename_dialog.html.erb
@@ -6,7 +6,7 @@
         <p class="text-xl"><%= I18n.t('dialog.edit_title') %></p>
       </div>
       <div class="max-h-[calc(100vh-212px)] overflow-auto">
-        <div class="w-full sm:w-[656px] p-6">
+        <div class="w-full p-6">
           <%= f.text_area :title, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
           <div class="font-xs mt-2 text-[rgb(112,109,101)]">
             <span data-word-counter-target="counter"></span>/<%= plan_title_max_length %>

--- a/app/views/plans/_setting_dialog.html.erb
+++ b/app/views/plans/_setting_dialog.html.erb
@@ -4,7 +4,7 @@
       <p class="my-0 text-xl"><%= I18n.t('settings.title') %></p>
     </div>
     <div class="max-h-[calc(100vh-212px)] overflow-auto">
-      <div class="w-full sm:w-[656px] p-6 border-b border-[rgb(214,211,208)]">
+      <div class="w-full p-6 border-b border-[rgb(214,211,208)]">
         <div class="py-2 w-full">
           <div><%= f.label :password, I18n.t('settings.set_password'), class: "text-[rgb(112,109,101)] font-bold" %></div>
           <div class="mt-2"><%= I18n.t('settings.password_expression') %></div>

--- a/app/views/profiles/_dialog.html.erb
+++ b/app/views/profiles/_dialog.html.erb
@@ -5,7 +5,7 @@
         <p class="text-xl"><%= I18n.t('dialog.edit_introduce') %></p>
       </div>
       <div class="max-h-[calc(100vh-212px)] overflow-auto">
-        <div class="w-full sm:w-[656px] p-6">
+        <div class="w-full p-6">
           <%= f.text_area :introduce, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
           <div class="font-xs mt-2 text-[rgb(112,109,101)]">
             <span data-word-counter-target="counter"></span>/<%= profile_introduce_max_length %>

--- a/app/views/schedules/_card.html.erb
+++ b/app/views/schedules/_card.html.erb
@@ -65,7 +65,7 @@
                     <p class="text-xl"><%= I18n.t('dialog.edit_memo', title: schedule.title) %></p>
                   </div>
                   <div class="max-h-[calc(100vh-212px)] overflow-auto">
-                    <div class="w-[656px] p-6">
+                    <div class="w-full p-6">
                       <%= f.hidden_field :edit_memo_schedule_id, value: schedule.id %>
                       <%= f.text_area :memo, value: @plan.plan_schedules.find { _1.schedule == schedule }&.memo, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
                       <div class="font-xs mt-2 text-[rgb(112,109,101)]">

--- a/app/views/teams/_rename_dialog.html.erb
+++ b/app/views/teams/_rename_dialog.html.erb
@@ -15,7 +15,7 @@
               </ul>
             </div>
           <% end %>
-          <div class="w-full: sm:w-[656px] p-6">
+          <div class="w-full p-6">
             <%= f.text_area :name, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
             <div class="font-xs mt-2 text-[rgb(112,109,101)]">
               <span data-word-counter-target="counter"></span>/<%= team_name_max_length %>


### PR DESCRIPTION
`sm:w-[656px] `がついているダイアログではスクショの用に余白が入ってしまうため、スタイルを削除しました。

| before  | after   |
| --- | --- |
| ![image](https://github.com/kufu/mie/assets/53547520/1604207c-3a25-4bc8-ad2d-291666574c2d) | ![image](https://github.com/kufu/mie/assets/53547520/91d73f49-0bc3-4554-bc97-150ab9cafcdd) |