### PR TITLE
チーム画面のモバイル対応

### DIFF
--- a/app/views/teams/_mobile_table_row.html.erb
+++ b/app/views/teams/_mobile_table_row.html.erb
@@ -1,0 +1,15 @@
+<% @selected = @plan.plan_schedules.map(&:schedule).any? { row.schedules.include?(_1) } %>
+<p class="text-xl font-normal mr-4 shrink-0"><%= row.start_end %></p>
+<% filtered_profiles = @team.active_profiles.reject { |prof| row.schedules.any? { @member_schedules_map[prof.id].include?(_1.id) } } %>
+<% if filtered_profiles.any? %>
+  <div class="p-2 pl-4 flex flex-wrap">
+    <% filtered_profiles.each do |prof| %>
+      <img src="<%= prof.avatar_url %>" class="h-12 w-12 rounded-full border-2 border-black ml-[-16px] mt-1" />
+    <% end %>
+  </div>
+<% end %>
+<% track_list.each do |track| %>
+  <% if row.tracks[track] %>
+    <div class="p-2"><%= render("schedules/card", schedule: row.tracks[track], mode: :team, inactive: @selected) %></div>
+  <% end %>
+<% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -61,7 +61,7 @@
   <div class="mt-4 overflow-y-auto">
     <% @schedule_table.days.each do |day| %>
       <div id="schedule-<%= day %>" class="schedule-table hidden">
-        <table class="h-full w-full border-collapse border-spacing-0">
+        <table class="hidden sm:table h-full w-full border-collapse border-spacing-0">
           <thead>
             <th class="p-4 text-sm leading-4 border border-solid border-[rgb(214,211,208)] w-auto min-w-[184px] text-left"><%= I18n.t('table.start_end') %></th>
             <% @schedule_table[day].track_list.each do |track| %>
@@ -95,6 +95,11 @@
             <% end %>
           </tbody>
         </table>
+        <div class="sm:hidden" id="mobile-table-<%= day %>">
+          <% @schedule_table[day].rows.each do |row| %>
+            <%= render partial: 'mobile_table_row', locals: { row: row, plan: @plan, track_list: @schedule_table[day].track_list } %>
+          <% end %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
チーム画面をモバイル対応しました。既存のタイムテーブルのUIを踏襲しつつ、チーム画面のPCのUIに表示されているものを表示しています。気になるところあればFBください！

| pc  | after |
| --- | --- |
| ![image](https://github.com/kufu/mie/assets/53547520/5326d411-e2a1-4f2d-8c9e-915c1474b0f1) | ![image](https://github.com/kufu/mie/assets/53547520/90daab8e-539a-480e-9eea-eb2c84fce4eb) |