### PR TITLE
Team page refers to always newest plan.

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -14,7 +14,7 @@ class TeamsController < ApplicationController
     @schedules = @event.schedules.includes(:speakers, :track).order(:start_at)
     @schedule_table = Schedule::Tables.new(@schedules)
     @member_schedules_map = @team.profiles.to_h do |profile|
-      [profile.id, profile.user.plans.find_by(event: @event)&.plan_schedules&.map(&:schedule_id) || []]
+      [profile.id, profile.user.current_plan&.plan_schedules&.map(&:schedule_id) || []]
     end
   end
 


### PR DESCRIPTION
# Team page refers to always newest plan

User has many plans includes that belongs to same event.

This application defines `current_plan` as newest Plan that belongs to newest Event. Fix to refer to `current_plan` on team page.

ユーザーは、同一のイベントに関しても複数のPlanを持つことができてしまいます。

スケジュールアプリとしての”現在の視聴予定”の定義は、最新のイベントに紐づく最も新しく作られた予定なので、チームページでは常にそちらを参照するように修正しました。

Asked from: https://twitter.com/kokuyouwind/status/1788862513590997041