### PR TITLE
トップページのリンクにmargin追加

### DIFF
--- a/app/views/static/top.html.erb
+++ b/app/views/static/top.html.erb
@@ -23,7 +23,7 @@
   <div class="sm:w-[600px] my-6 text-[var(--textColor)] text-base leading-[200%]">
       <%= I18n.t('application.intro') %>
   </div>
-  <div class="mb-4">
+  <div class="mb-4 space-y-2">
     <p class=""><a href="<%= @event.event_theme.site_url %>">Official Site</a></p>
     <p class=""><a href="https://twitter.com/rubykaigi">Twitter</a></p>
     <p class=""><a href="https://smarthr.co.jp/">SmartHR</a></p>


### PR DESCRIPTION
トップページのリンクが近くて誤爆りそうなので、いい感じにmargin入れておきました。
良さそうだったらマージしてください。


### 変更前
![image](https://github.com/kufu/mie/assets/15830143/e6f810ae-e486-4f8c-922a-af368ee88371)

### 変更後
![image](https://github.com/kufu/mie/assets/15830143/50668fb8-42de-4ebe-8918-94bf804ed6af)
