### PR TITLE
[bugfix] スケジュール追加時に500エラーにならないようにする

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -151,6 +151,7 @@ class PlansController < ApplicationController
     nil
   end
 
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def set_attributes_for_turbo_stream
     @schedules = @event.schedules.includes(:speakers, :track).order(:start_at)
     @schedule_table = Schedule::Tables.new(@schedules)
@@ -173,4 +174,5 @@ class PlansController < ApplicationController
       [profile.id, profile.user.plans.find_by(event: @event)&.plan_schedules&.map(&:schedule_id) || []]
     end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -168,5 +168,9 @@ class PlansController < ApplicationController
         end
       end
     end
+
+    @friends_schedules_map = @user.profile.friend_profiles.to_h do |profile|
+      [profile.id, profile.user.plans.find_by(event: @event)&.plan_schedules&.map(&:schedule_id) || []]
+    end
   end
 end


### PR DESCRIPTION
バグの再現手順
- 任意のスケジュールを視聴予定に追加する
- 500エラーになる
```
undefined method `[]' for nil
/Users/emine.ikuta/ghq/github.com/kufu/mie/app/views/schedules/_table_row.html.erb:19:in `block (2 levels) in _app_views_schedules__table_row_html_erb__4089312420943008097_42640'
```