### PR TITLE
Change friend QR code limit

### DIFF
--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -10,8 +10,8 @@ class FriendsController < ApplicationController
 
     if @trigger
       @trigger.key = SecureRandom.uuid
-      @trigger.expires_at = Time.zone.now + 30.seconds
-      @trigger.amount = 1
+      @trigger.expires_at = Time.zone.now + 90.seconds
+      @trigger.amount = 7
     else
       @trigger = new_trigger
     end
@@ -51,8 +51,8 @@ class FriendsController < ApplicationController
           action: :craete
         }
       ],
-      expires_at: Time.zone.now + 30.seconds,
-      amount: 1
+      expires_at: Time.zone.now + 90.seconds,
+      amount: 7
     )
   end
 end


### PR DESCRIPTION
I decided to up to 90 seconds to expire QR code and 7 peoples can make friend with 1 QR code because of I heard some reviews that 30 seconds are too short to pass OAuth, limit 1 person is not useful when talk with some peoples.

30秒ではOAuthを突破する前に失効する、1人限定だと数名で話しているときにわちゃわちゃする、というレビューを実地でもらったので、90秒の7人に引き上げることにしました。