### PR TITLE
Trophy detail dialog on Profile page

### DIFF
--- a/app/controllers/trophies_controller.rb
+++ b/app/controllers/trophies_controller.rb
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
 
 class TrophiesController < ApplicationController
+  before_action :set_trophy, only: %i[show]
+  def show; end
+
+  private
+
+  def set_trophy
+    @trophy = Trophy.find(params[:id])
+  end
 end

--- a/app/controllers/trophies_controller.rb
+++ b/app/controllers/trophies_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class TrophiesController < ApplicationController
+end

--- a/app/helpers/trophies_helper.rb
+++ b/app/helpers/trophies_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module TrophiesHelper
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -72,7 +72,28 @@
               <% if @profile&.trophies&.present? %>
                 <div class="flex flex-wrap gap-1 py-2">
                   <% @profile.trophies.order(:order).each do |trophy| %>
-                    <img src="<%= image_url trophy.icon_url %>" class="rounded-full h-12 w-12 border-4 <%= trophy.common? ? "border-slate-950" : trophy.uncommon? ? "border-gray-300" : trophy.rare? ? "border-amber-300" : "border-orange-600" %>" />
+                    <div data-controller="dialog" data-dialog-element-id-value="<%= trophy.id %>-dialog">
+                      <img
+                        data-action="click->dialog#open"
+                        src="<%= image_url trophy.icon_url %>"
+                        class="rounded-full h-12 w-12 border-4 <%= trophy.common? ? "border-slate-950" : trophy.uncommon? ? "border-gray-300" : trophy.rare? ? "border-amber-300" : "border-orange-600" %>"
+                      />
+                      <dialog id="<%= trophy.id %>-dialog" class="dialog">
+                        <div class="border-b-[1px] border-[rgb(214,211,208)] py-4 px-6 flex flex-col justify-start">
+                          <p class="text-xl"><%= trophy.name %></p>
+                        </div>
+                        <div class="max-h-[calc(100vh-212px)] overflow-auto">
+                          <div class="w-full p-6">
+                            <%= turbo_frame_tag trophy, src: trophy_path(trophy), loading: :lazy  %>
+                          </div>
+                        </div>
+                        <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
+                          <div class="flex justify-end">
+                            <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+                          </div>
+                        </div>
+                      </dialog>
+                    </div>
                   <% end %>
                 </div>
               <% end %>

--- a/app/views/trophies/show.html.erb
+++ b/app/views/trophies/show.html.erb
@@ -1,4 +1,7 @@
-<div class="flex flex-col items-center gap-4">
-  <img src="<%= image_url @trophy.icon_url %>" class="rounded-full h-24 w-24 border-4 <%= @trophy.common? ? "border-slate-950" : @trophy.uncommon? ? "border-gray-300" : @trophy.rare? ? "border-amber-300" : "border-orange-600" %>" />
-  <p><%= @trophy.description %></p>
-</div>
+<%= turbo_frame_tag @trophy do %>
+  <div class="flex flex-col items-center gap-4">
+    <img src="<%= image_url @trophy.icon_url %>" class="rounded-full h-24 w-24 border-4 <%= @trophy.common? ? "border-slate-950" : @trophy.uncommon? ? "border-gray-300" : @trophy.rare? ? "border-amber-300" : "border-orange-600" %>" />
+    <p><%= @trophy.description %></p>
+    <p><%= I18n.t("trophy.rarity") %>: <%= @trophy.human_attribute_enum(:rarity) %></p>
+  </div>
+<% end %>

--- a/app/views/trophies/show.html.erb
+++ b/app/views/trophies/show.html.erb
@@ -1,0 +1,4 @@
+<div class="flex flex-col items-center gap-4">
+  <img src="<%= image_url @trophy.icon_url %>" class="rounded-full h-24 w-24 border-4 <%= @trophy.common? ? "border-slate-950" : @trophy.uncommon? ? "border-gray-300" : @trophy.rare? ? "border-amber-300" : "border-orange-600" %>" />
+  <p><%= @trophy.description %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,9 @@ en:
       - "List all members plan in one page"
       - "User can join to only one team"
 
+  trophy:
+    rarity: "Rarity"
+
   time:
     formats:
       default: "%Y-%m-%d %H:%M"
@@ -145,6 +148,11 @@ en:
         admin: Admin
         member: Member
         invitation: Wait for accept
+      trophy/rarity:
+        common: Common
+        uncommon: Uncommon
+        rare: Rare
+        mythic_rare: Mythic Rare
 
   application:
     intro: |-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -92,6 +92,8 @@ ja:
       - "同じチームに所属しているメンバーの予定が、一つのページで一覧できるようになります"
       - "ユーザーは1つのチームにしか所属することができません"
 
+  trophy:
+    rarity: "レアリティ"
 
   errors:
     time_overlap_error: "「%{left}」と「 %{right}」は、時間が重複しているため同時に選択できません"
@@ -115,6 +117,11 @@ ja:
         admin: 管理者
         member: メンバー
         invitation: 招待中
+      trophy/rarity:
+        common: コモン
+        uncommon: アンコモン
+        rare: レア
+        mythic_rare: 神話レア
 
   application:
     intro: |-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
 
   resources :triggers, only: %i[show]
 
+  resources :trophies, only: %i[show]
+
   namespace :admin do
     resources :triggers, only: %i[index show edit update]
   end

--- a/test/controllers/trophies_controller_test.rb
+++ b/test/controllers/trophies_controller_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TrophiesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Add trophy detail dialog on Profile page.
プロフィールページに、トロフィの詳細ダイアログを追加。

<img width="389" alt="スクリーンショット 2024-05-15 0 22 55" src="https://github.com/kufu/mie/assets/2846039/7bfda9c3-41a9-4da0-9edf-0d95b13cd99c">
