### PR TITLE
Update locale by URLSearchParams in locale_controller.js

### DIFF
--- a/app/javascript/controllers/locale_controller.js
+++ b/app/javascript/controllers/locale_controller.js
@@ -14,16 +14,16 @@ export default class extends Controller {
 
   connect () {
     if (this.currentValue === '' && !this.isTestEnvironment) {
-      Turbo.visit(this.nonSearchParamURL(window.location) + '?' + new URLSearchParams({ locale: dayjs.tz.guess() }));
+      const location = new URL(window.location.href);
+      location.searchParams.set('locale', dayjs.tz.guess());
+      Turbo.visit(location.href);
     }
   }
 
   change (e) {
-    Turbo.visit(this.nonSearchParamURL(window.location) + '?' + new URLSearchParams({ locale: e.target.value }));
-  }
-
-  nonSearchParamURL (location) {
-    return location.toString().split('?')[0];
+    const location = new URL(window.location.href);
+    location.searchParams.set('locale', e.target.value);
+    Turbo.visit(location.href);
   }
 
   get isTestEnvironment() {


### PR DESCRIPTION
## How to reproduce

https://github.com/kufu/mie/assets/4487291/227a0c18-d4f9-42e9-8be2-1e52b688f7d0

1. Visit to `https://rubykaigi.smarthr.co.jp/2024/schedules`
2. Click date tab e.g. `2024-05-15`
3. Change locale 
4. Reload page.

The URL `https://rubykaigi.smarthr.co.jp/2024/schedules#2024-05-15?locale=Asia%2FKamchatka` is invalid. (Sorry, I can't find its specification from [URL Spec](https://url.spec.whatwg.org))

## Fix
Use the `URLSearchParams` interface.

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/set

https://github.com/kufu/mie/assets/4487291/bb72cdb9-1839-4f2b-b827-22c37b1195b1


