### PR TITLE
Use <button type="button"> instead of <a href="#">

### DIFF
--- a/app/views/members/dialog.html.erb
+++ b/app/views/members/dialog.html.erb
@@ -77,7 +77,7 @@
 
     <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
       <div class="flex justify-end">
-        <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+        <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
       </div>
     </div>
   <% end %>

--- a/app/views/plans/_description_dialog.html.erb
+++ b/app/views/plans/_description_dialog.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
         <div class="flex justify-end">
-          <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+          <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
           <%= f.submit I18n.t('button.save'), data: { action: "click->dialog#close", "word-counter-target": "submit" }, class: "primary-button" %>
         </div>
       </div>

--- a/app/views/plans/_password_dialog.html.erb
+++ b/app/views/plans/_password_dialog.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="flex flex-col border-t border-[rgb(214,211,208)] py-4 px-6">
       <div class="flex justify-end">
-        <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+        <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
         <%= f.submit I18n.t('button.make_editable'), data: { action: "click->dialog#close", "word-counter-target": "submit" }, class: "primary-button" %>
       </div>
     </div>

--- a/app/views/plans/_rename_dialog.html.erb
+++ b/app/views/plans/_rename_dialog.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
         <div class="flex justify-end">
-          <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+          <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
           <%= f.submit I18n.t('button.save'), data: { action: "click->dialog#close", "word-counter-target": "submit" }, class: "primary-button" %>
         </div>
       </div>

--- a/app/views/plans/_setting_dialog.html.erb
+++ b/app/views/plans/_setting_dialog.html.erb
@@ -36,7 +36,7 @@
     </div>
     <div class="flex flex-col border-t border-[rgb(214,211,208)] py-4 px-6">
       <div class="flex justify-end">
-        <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+        <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
         <%= f.submit I18n.t('button.save'), data: { action: "click->dialog#close", "word-counter-target": "submit" }, class: "primary-button" %>
       </div>
     </div>

--- a/app/views/profiles/_dialog.html.erb
+++ b/app/views/profiles/_dialog.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
         <div class="flex justify-end">
-          <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+          <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
           <%= f.submit I18n.t('button.save'), data: { action: "click->dialog#close", "word-counter-target": "submit" }, class: "primary-button" %>
         </div>
       </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -48,7 +48,7 @@
                       </div>
                       <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
                         <div class="flex justify-end">
-                          <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+                          <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
                         </div>
                       </div>
                     </dialog>
@@ -89,7 +89,7 @@
                         </div>
                         <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
                           <div class="flex justify-end">
-                            <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+                            <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
                           </div>
                         </div>
                       </dialog>

--- a/app/views/schedules/_card.html.erb
+++ b/app/views/schedules/_card.html.erb
@@ -76,7 +76,7 @@
                   </div>
                   <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
                     <div class="flex justify-end">
-                      <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+                      <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
                       <%= f.submit I18n.t('button.save'), data: { action: "click->dialog#close", "word-counter-target": "submit" }, class: "primary-button" %>
                     </div>
                   </div>

--- a/app/views/teams/_rename_dialog.html.erb
+++ b/app/views/teams/_rename_dialog.html.erb
@@ -24,7 +24,7 @@
         </div>
         <div class="border-t-[1px] border-[rgb(214,211,208)] flex flex-col py-4 px-6">
           <div class="flex justify-end">
-            <a href="#" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></a>
+            <button type="button" class="normal-button mr-2" data-action="click->dialog#close"><%= I18n.t('button.close')%></button>
             <%= f.submit I18n.t('button.save'), data: { action: "click->dialog#disable", "word-counter-target": "submit" }, class: "primary-button" %>
           </div>
         </div>


### PR DESCRIPTION
In turbo frames, \<a\> and \<button\> are trigger of turbo request event if that isn't have target, specially \<button\> has default attribute type="submit".
If you use these element to close modal that inner element of \<form\> tag, useless turbo request are triggered.

To avoid these useless access, use \<button type="button"\> element. This is a pure button, no submit, no reset, just a button.