### PR TITLE
Extract PlanSchedule logics from PlansController to ItemsController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   rescue_from Exception, with: :server_error
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActionController::RoutingError, with: :not_found
+  rescue_from ActionController::ParameterMissing, with: :bad_request # TODO: Remove in Rails8
 
   def set_user
     @user = User.find(session[:user_id]) if session[:user_id]
@@ -35,6 +36,12 @@ class ApplicationController < ActionController::Base
     end
 
     render template: 'errors/not_found', status: 404, layout: 'application', content_type: 'text/html'
+  end
+
+  def bad_request(err = nil)
+    Rails.logger.debug("#{err}\n#{err.backtrace.join("\n")}") if err
+
+    render status: :bad_request, body: nil
   end
 
   def server_error(err)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,7 @@
+class ItemsController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,7 +49,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:memo)
+    params.require(:plan_schedule).permit(:memo)
   end
 
   def set_item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,97 @@
+# frozen_string_literal: true
+
 class ItemsController < ApplicationController
+  include EventRouting
+  include ScheduleTable
+
+  before_action :set_event
+  before_action :set_item, only: %i[update destroy]
+  before_action :set_plan
+  before_action :build_item, only: %i[create]
+  before_action :check_user_owns_plan
+  before_action :check_item_belongs_to_event
+
   def create
+    if @plan.valid?
+      @item.save!
+    else
+      flash[:error] = @plan.errors.messages[:schedules]
+      redirect_to event_plan_path(@plan, event_name: @event.name) and return
+    end
+    @plan.update!(initial: false) if @plan.initial
+
+    if request.format.turbo_stream?
+      set_attributes_for_turbo_stream
+      render 'update'
+    else
+      redirect_to event_plan_path(@plan, event_name: @event.name)
+    end
+  end
+
+  def update
+    @item.update!(item_params)
+    render 'schedules/_card', locals: { schedule: @item.schedule, mode: :plan, inactive: false }
   end
 
   def destroy
+    @item.destroy!
+    @plan.update!(initial: false)
+
+    case params[:mode]
+    when 'schedule'
+      set_attributes_for_turbo_stream
+      render 'update'
+    when 'plan'
+      redirect_to event_plan_path(@plan, event_name: @event.name)
+    end
   end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:memo)
+  end
+
+  def set_item
+    @item = PlanSchedule.find(params[:id])
+  end
+
+  def build_item
+    @item = @plan.plan_schedules.build(schedule: Schedule.find(params[:schedule_id]))
+  end
+
+  def set_plan
+    @plan = @item ? @item.plan : Plan.find(params[:plan_id])
+  end
+
+  def check_user_owns_plan
+    render status: :bad_request, body: nil if @plan.nil?
+    render status: :forbidden, body: nil unless @user.plans.include?(@plan)
+  end
+
+  def check_item_belongs_to_event
+    render status: :not_found, body: nil unless @item.schedule.track.event == @event
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def set_attributes_for_turbo_stream
+    @schedules = @event.schedules.includes(:speakers, :track).order(:start_at)
+    @schedule_table = Schedule::Tables.new(@schedules)
+
+    @row, @track_list = catch(:abort) do
+      @schedule_table.days.each do |day|
+        @table = @schedule_table[day]
+        @table.rows.each do |row|
+          throw :abort, [row, @table.track_list] if row.schedules.map(&:id).include?(params[:schedule_id])
+        end
+      end
+    end
+
+    return unless @user.profile
+
+    @friends_schedules_map = @user.profile.friend_profiles.to_h do |profile|
+      [profile.id, profile.user.plans.find_by(event: @event)&.plan_schedules&.map(&:schedule_id) || []]
+    end
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -60,7 +60,7 @@ class PlansController < ApplicationController
   end
 
   def check_user_owns_plan
-    render status: :bad_request, body: nil  if @plan.nil?
+    render status: :bad_request, body: nil if @plan.nil?
     render status: :forbidden, body: nil unless @user.plans.include?(@plan)
   end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -13,19 +13,8 @@ class PlansController < ApplicationController
   end
 
   def update
-    target = switch_update_type_and_exec
-
-    if plan_add_or_remove? && params[:mode] == 'schedule'
-      set_attributes_for_turbo_stream
-      render 'update'
-    elsif plan_add_or_remove? && params[:mode] == 'plan'
-      redirect_to event_plan_path(@plan, event_name: @event.name)
-    elsif target
-      render 'schedules/_card',
-             locals: { schedule: target, mode: params[:edit_memo_schedule_id] ? :plan : :schedule, inactive: false }
-    else
-      redirect_to event_plan_url(@plan, event_name: @event.name)
-    end
+    @plan.update!(plan_params)
+    redirect_to event_plan_url(@plan, event_name: @event.name)
   end
 
   def editable
@@ -45,62 +34,19 @@ class PlansController < ApplicationController
   def create
     create_and_set_user unless @user
     @plan = @user.plans.where(event: @event).create!(plan_params)
-    add_and_remove_plans if plan_add_or_remove?
+    add_plan(params[:plan][:add_schedule_id]) if params[:plan][:add_schedule_id]
     redirect_to event_schedules_path(event_name: @plan.event.name)
   end
 
   private
 
-  def switch_update_type_and_exec
-    if plan_add_or_remove?
-      add_and_remove_plans
-    elsif params[:edit_memo_schedule_id]
-      edit_memo
-    elsif params[:plan][:description]
-      edit_description
-    elsif params[:plan][:public]
-      edit_password_and_visibility
-    elsif params[:plan][:title]
-      edit_title
-    else
-      head :bad_request
-    end
-  end
-
   def plan_params
-    params.require(:plan).permit(:title, :description, :public, :initial)
-  end
-
-  def plan_add_or_remove?
-    if params[:plan]
-      params[:plan][:add_schedule_id] || params[:plan][:remove_schedule_id]
-    else
-      params[:add_schedule_id] || params[:remove_schedule_id]
-    end
-  end
-
-  def redirect_path_with_identifier(target)
-    identifier = target&.start_at&.strftime('%Y-%m-%d')
-    (request.referer || schedules_path) + (identifier ? "##{identifier}" : '')
+    params.require(:plan).permit(:title, :description, :public)
   end
 
   def set_plan
-    @plan = Plan.on_event(@event).find(params[:id] || params[:plan_id])
+    @plan = Plan.on_event(@event).find(params[:id])
     raise ActiveRecord::RecordNotFound if @plan.user != @user && !@plan.public?
-  rescue StandardError => e
-    @plan ||= Plan.new
-    raise e
-  end
-
-  def add_and_remove_plans
-    ret = nil
-    add_id = params[:add_schedule_id] || params.dig(:plan, :add_schedule_id)
-    remove_id = params[:remove_schedule_id] || params.dig(:plan, :remove_schedule_id)
-    ActiveRecord::Base.transaction do
-      ret = add_plan(add_id) if add_id
-      ret = remove_plan(remove_id) if remove_id
-    end
-    ret
   end
 
   def add_plan(id)
@@ -109,34 +55,13 @@ class PlansController < ApplicationController
       ps.save!
     else
       flash[:error] = @plan.errors.messages[:schedules]
-      redirect_to event_schedules_path(event_name: @plan.event.name) && return
+      redirect_to event_schedules_path(event_name: @plan.event.name) and return
     end
-    @plan.update!(initial: false)
-    ps.schedule
-  end
-
-  def remove_plan(id)
-    schedule = Schedule.find(id)
-    @plan.plan_schedules.find_by(schedule:).destroy!
-    @plan.update!(initial: false)
-    schedule
-  end
-
-  def edit_memo
-    schedule = Schedule.find(params[:edit_memo_schedule_id])
-    plan_schedule = @plan.plan_schedules.find_by(schedule:)
-    plan_schedule.update!(memo: params[:memo])
-    schedule
-  end
-
-  def edit_description
-    @plan.update!(description: params[:plan][:description])
-    nil
   end
 
   def check_user_owns_plan
-    return render :bad_request if @plan.nil?
-    return render :bad_request unless @user.plans.include?(@plan)
+    render status: :bad_request, body: nil  if @plan.nil?
+    render status: :forbidden, body: nil unless @user.plans.include?(@plan)
   end
 
   def edit_password_and_visibility
@@ -145,36 +70,4 @@ class PlansController < ApplicationController
     @plan.save!
     nil
   end
-
-  def edit_title
-    @plan.update(title: params[:plan][:title])
-    nil
-  end
-
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  def set_attributes_for_turbo_stream
-    @schedules = @event.schedules.includes(:speakers, :track).order(:start_at)
-    @schedule_table = Schedule::Tables.new(@schedules)
-
-    target_schedule_id = params[:add_schedule_id] ||
-                         params.dig(:plan, :add_schedule_id) ||
-                         params[:remove_schedule_id] ||
-                         params.dig(:plan, :remove_schedule_id)
-
-    @row, @track_list = catch(:abort) do
-      @schedule_table.days.each do |day|
-        @table = @schedule_table[day]
-        @table.rows.each do |row|
-          throw :abort, [row, @table.track_list] if row.schedules.map(&:id).include?(target_schedule_id)
-        end
-      end
-    end
-
-    return unless @user.profile
-
-    @friends_schedules_map = @user.profile.friend_profiles.to_h do |profile|
-      [profile.id, profile.user.plans.find_by(event: @event)&.plan_schedules&.map(&:schedule_id) || []]
-    end
-  end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,0 +1,2 @@
+module ItemsHelper
+end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ItemsHelper
 end

--- a/app/views/items/create.html.erb
+++ b/app/views/items/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Items#create</h1>
+  <p>Find me in app/views/items/create.html.erb</p>
+</div>

--- a/app/views/items/destroy.html.erb
+++ b/app/views/items/destroy.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Items#destroy</h1>
+  <p>Find me in app/views/items/destroy.html.erb</p>
+</div>

--- a/app/views/items/update.turbo_stream.erb
+++ b/app/views/items/update.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%= turbo_stream.replace @row.turbo_stream_id do %>
+  <%= render partial: 'schedules/table_row', locals: { row: @row, plan: @plan, track_list: @track_list} %>
+<% end %>
+<%= turbo_stream.update "mobile-table-#{@table.day}" do %>
+  <% @table.rows.each do |row| %>
+    <%= render partial: 'schedules/mobile_table_row', locals: { row: row, plan: @plan, track_list: @table.track_list } %>
+  <% end %>
+<% end %>

--- a/app/views/schedules/_card.html.erb
+++ b/app/views/schedules/_card.html.erb
@@ -60,14 +60,13 @@
               <%= I18n.t('button.update_memo') %>
             </button>
             <dialog id="<%= memo_dialog_element_id %>" class="dialog max-w-[min(100vw-16px,800px)]">
-              <%= form_with(url: event_plan_path(@plan, event_name: @plan.event.name), method: :patch) do |f| %>
+              <%= form_with(url: event_item_url(@plan.plan_schedules.find { _1.schedule == schedule }, event_name: @plan.event.name), scope: 'plan_schedule', method: :patch) do |f| %>
                 <div data-controller="word-counter" data-word-counter-max-value="<%= plan_memo_max_length %>" class="">
                   <div class="border-b-[1px] border-[rgb(214,211,208)] py-4 px-6 flex flex-col justify-start">
                     <p class="text-xl"><%= I18n.t('dialog.edit_memo', title: schedule.title) %></p>
                   </div>
                   <div class="max-h-[calc(100vh-212px)] overflow-auto">
                     <div class="w-full p-6">
-                      <%= f.hidden_field :edit_memo_schedule_id, value: schedule.id, id: "#{schedule.id}-#{memo_dialog_element_id}" %>
                       <%= f.text_area :memo, value: @plan.plan_schedules.find { _1.schedule == schedule }&.memo, id: SecureRandom.uuid, class: "border opacity-100 rounded-md border border-[rgb(214,211,208)] bg-white p-2 text-[rgb(35,34,30)] w-full", data: { "word-counter-target": "source", action: "input->word-counter#calc" } %>
                       <div class="font-xs mt-2 text-[rgb(112,109,101)]">
                         <span data-word-counter-target="counter"></span>/<%= plan_memo_max_length %>
@@ -89,9 +88,7 @@
         <% unless mode == :team %>
           <div>
             <% if @plan.plan_schedules.map(&:schedule).include?(schedule) # to avoid n+1 %>
-              <%= form_with(url: event_plan_url(@plan, event_name: @plan.event.name), method: 'PATCH' ) do |form| %>
-                <%= form.hidden_field :remove_schedule_id, value: schedule.id, id: SecureRandom.uuid %>
-                <%= form.hidden_field :mode, value: mode, id: SecureRandom.uuid %>
+              <%= form_with(url: event_item_url(@plan.plan_schedules.find_by(schedule:), event_name: @plan.event.name), method: :delete ) do |form| %>
                 <%= form.submit I18n.t('card.remove'), class: "remove-plan-button p-2 text-sm font-bold min-h-5 normal-button", data: { turbo_frame: "event_#{@event.id}" } %>
               <% end %>
             <% elsif @plan.new_record? %>
@@ -120,7 +117,7 @@
                   <div class="flex flex-col border-solid border-t border-[rgb(214,211,208)] py-4 px-6">
                     <div class="flex justify-end">
                       <button class="normal-button" data-action="click->dialog#close"><%= I18n.t('button.close') %></button>
-                      <%= form_with(url: event_plans_url(@plan, event_name: @plan.event.name), model: @plan, method: 'POST') do |form| %>
+                      <%= form_with(url: event_plans_url(@plan, event_name: @plan.event.name), model: @plan, method: :post) do |form| %>
                         <%= form.hidden_field :title %>
                         <%= form.hidden_field :description %>
                         <%= form.hidden_field :public %>
@@ -134,9 +131,8 @@
                 </dialog>
               </div>
             <% else %>
-              <%= form_with(url: event_plan_url(@plan, event_name: @plan.event.name), method: 'PATCH' ) do |form| %>
-                <%= form.hidden_field :add_schedule_id, value: schedule.id %>
-                <%= form.hidden_field :mode, value: mode %>
+              <%= form_with(url: event_plan_items_url(plan_id: @plan.id, event_name: @plan.event.name), method: :post ) do |form| %>
+                <%= form.hidden_field :schedule_id, value: schedule.id %>
                 <%= form.submit inactive ? I18n.t('card.inactive') : I18n.t('card.add'), class: "add-plan-button p-2 text-sm font-bold min-h-5 normal-button", disabled: inactive, data: { turbo_frame: "event_#{@event.id}"} %>
               <% end %>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,8 +24,14 @@ Rails.application.routes.draw do
       scope module: :plans do
         resource :ogp, only: %i[show]
       end
+
+      resources :items, only: %i[create]
     end
+
+    resources :items, only: %i[update destroy]
   end
+
+  resolve('PlanSchedule') { [:event, :item] }
 
   resources :teams, except: :index do
     resources :members, only: %i[create update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     resources :items, only: %i[update destroy]
   end
 
-  resolve('PlanSchedule') { [:event, :item] }
+  resolve('PlanSchedule') { %i[event item] }
 
   resources :teams, except: :index do
     resources :members, only: %i[create update destroy]

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ItemsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -3,7 +3,126 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    omniauth_callback_uid(1234) # profile_one
+    get '/auth/github/callback'
+  end
+
+  test 'Add new item to plan' do
+    assert_difference('PlanSchedule.count', 1) do
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:six).id }
+    end
+    assert_redirected_to event_plan_path(plans(:one), event_name: events(:party).name)
+  end
+
+  test 'Add new item to plan with turbo frames' do
+    assert_difference('PlanSchedule.count', 1) do
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:six).id }, as: :turbo_stream
+    end
+    assert_response :ok
+  end
+
+  test 'Reject add new item to plan when crossover item has exists' do
+    assert_no_difference('PlanSchedule.count') do
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:one_crossover).id }
+    end
+    assert_redirected_to event_plan_path(plans(:one), event_name: events(:party).name)
+  end
+
+  test 'Reject add new item to plan when crossover item has exists with turbo frames' do
+    assert_no_difference('PlanSchedule.count') do
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:one_crossover).id }, as: :turbo_stream
+    end
+    assert_redirected_to event_plan_path(plans(:one), event_name: events(:party).name)
+  end
+
+  test 'Change plan initial flag turn false if add new item succeed' do
+    plan = plans(:one)
+    plan.initial = true
+    plan.save!
+
+    post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:six).id }
+    plan.reload
+
+    assert_not plan.initial
+  end
+
+  test 'Not change plan initial flag turn false if add new item failed' do
+    plan = plans(:one)
+    plan.initial = true
+    plan.save!
+
+    post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:one_crossover).id }
+    plan.reload
+
+    assert plan.initial
+  end
+
+  test 'Reject add item to plan when item is not belongs to event' do
+    assert_no_difference('PlanSchedule.count') do
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:dojo_one).id }
+    end
+    assert_response :not_found
+  end
+
+  test 'Reject add new item to plan that not owned' do
+    assert_no_difference('PlanSchedule.count') do
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:two).id), params: { schedule_id: schedules(:six).id }
+    end
+    assert_response :forbidden
+  end
+
+  test 'Modify items memo' do
+    item = plans(:one).plan_schedules.find_by(schedule: schedules(:one))
+    patch event_item_url(item, event_name: events(:party).name), params: { plan_schedule: { memo: 'test' } }
+    item.reload
+
+    assert_equal 'test', item.memo
+  end
+
+  test 'Return bad request when modify items memo unless param' do
+    item = plans(:one).plan_schedules.find_by(schedule: schedules(:one))
+    patch event_item_url(item, event_name: events(:party).name), params: {}
+    assert_response :bad_request
+  end
+
+  test 'Reject modify item when item is not owned' do
+    item = plans(:two).plan_schedules.create!(schedule: schedules(:dojo_one))
+    patch event_item_url(item, event_name: events(:party).name), params: { plan_schedule: { memo: 'test' } }
+    assert_response :forbidden
+  end
+
+  test 'Remove item from plan' do
+    plan = plans(:one)
+    item = plan.plan_schedules.find_by(schedule: schedules(:one))
+
+    assert_difference('PlanSchedule.count', -1) do
+      delete event_item_url(item, event_name: events(:party).name)
+    end
+
+    assert_response :ok
+  end
+
+  test 'Reject delete other users item' do
+    plan = plans(:two)
+    item = plan.plan_schedules.create!(schedule: schedules(:dojo_one))
+
+    assert_no_difference('PlanSchedule.count') do
+      delete event_item_url(item, event_name: events(:party).name)
+    end
+
+    assert_response :forbidden
+  end
+
+  test 'Reject delete other event item' do
+    user = users(:one)
+    plan = user.plans.create!(event: events(:dojo), title: 'delete test')
+    item = plan.plan_schedules.create!(schedule: schedules(:dojo_one))
+
+    assert_no_difference('PlanSchedule.count') do
+      delete event_item_url(item, event_name: events(:party).name)
+    end
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -10,28 +10,32 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
   test 'Add new item to plan' do
     assert_difference('PlanSchedule.count', 1) do
-      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:six).id }
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+           params: { schedule_id: schedules(:six).id }
     end
     assert_redirected_to event_plan_path(plans(:one), event_name: events(:party).name)
   end
 
   test 'Add new item to plan with turbo frames' do
     assert_difference('PlanSchedule.count', 1) do
-      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:six).id }, as: :turbo_stream
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+           params: { schedule_id: schedules(:six).id }, as: :turbo_stream
     end
     assert_response :ok
   end
 
   test 'Reject add new item to plan when crossover item has exists' do
     assert_no_difference('PlanSchedule.count') do
-      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:one_crossover).id }
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+           params: { schedule_id: schedules(:one_crossover).id }
     end
     assert_redirected_to event_plan_path(plans(:one), event_name: events(:party).name)
   end
 
   test 'Reject add new item to plan when crossover item has exists with turbo frames' do
     assert_no_difference('PlanSchedule.count') do
-      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:one_crossover).id }, as: :turbo_stream
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+           params: { schedule_id: schedules(:one_crossover).id }, as: :turbo_stream
     end
     assert_redirected_to event_plan_path(plans(:one), event_name: events(:party).name)
   end
@@ -41,7 +45,8 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     plan.initial = true
     plan.save!
 
-    post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:six).id }
+    post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+         params: { schedule_id: schedules(:six).id }
     plan.reload
 
     assert_not plan.initial
@@ -52,7 +57,8 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     plan.initial = true
     plan.save!
 
-    post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:one_crossover).id }
+    post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+         params: { schedule_id: schedules(:one_crossover).id }
     plan.reload
 
     assert plan.initial
@@ -60,14 +66,16 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
 
   test 'Reject add item to plan when item is not belongs to event' do
     assert_no_difference('PlanSchedule.count') do
-      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id), params: { schedule_id: schedules(:dojo_one).id }
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:one).id),
+           params: { schedule_id: schedules(:dojo_one).id }
     end
     assert_response :not_found
   end
 
   test 'Reject add new item to plan that not owned' do
     assert_no_difference('PlanSchedule.count') do
-      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:two).id), params: { schedule_id: schedules(:six).id }
+      post event_plan_items_url(event_name: events(:party).name, plan_id: plans(:two).id),
+           params: { schedule_id: schedules(:six).id }
     end
     assert_response :forbidden
   end

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -20,7 +20,8 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
 
   test 'Create plan' do
     assert_difference('Plan.count') do
-      post event_plans_path(event_name: events(:dojo).name), params: { plan: { title: 'test', description: 'test', public: true, initial: false } }
+      post event_plans_path(event_name: events(:dojo).name),
+           params: { plan: { title: 'test', description: 'test', public: true, initial: false } }
     end
 
     assert_redirected_to event_schedules_path(event_name: events(:dojo).name)
@@ -28,7 +29,9 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
 
   test 'Create plan with first item' do
     assert_difference('PlanSchedule.count') do
-      post event_plans_path(event_name: events(:dojo).name), params: { plan: { title: 'test', description: 'test', public: true, initial: false, add_schedule_id: schedules(:dojo_one).id }}
+      post event_plans_path(event_name: events(:dojo).name),
+           params: { plan: { title: 'test', description: 'test', public: true, initial: false,
+                             add_schedule_id: schedules(:dojo_one).id } }
     end
 
     assert_redirected_to event_schedules_path(event_name: events(:dojo).name)

--- a/test/controllers/plans_controller_test.rb
+++ b/test/controllers/plans_controller_test.rb
@@ -3,7 +3,67 @@
 require 'test_helper'
 
 class PlansControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    omniauth_callback_uid(1234) # profile_one
+    get '/auth/github/callback'
+  end
+
+  test 'Show plan' do
+    get event_plan_path(plans(:one), event_name: events(:party).name)
+    assert_response :ok
+  end
+
+  test 'Show other persons plan' do
+    get event_plan_path(plans(:two), event_name: events(:dojo).name)
+    assert_response :ok
+  end
+
+  test 'Create plan' do
+    assert_difference('Plan.count') do
+      post event_plans_path(event_name: events(:dojo).name), params: { plan: { title: 'test', description: 'test', public: true, initial: false } }
+    end
+
+    assert_redirected_to event_schedules_path(event_name: events(:dojo).name)
+  end
+
+  test 'Create plan with first item' do
+    assert_difference('PlanSchedule.count') do
+      post event_plans_path(event_name: events(:dojo).name), params: { plan: { title: 'test', description: 'test', public: true, initial: false, add_schedule_id: schedules(:dojo_one).id }}
+    end
+
+    assert_redirected_to event_schedules_path(event_name: events(:dojo).name)
+  end
+
+  test 'Update plan title' do
+    plan = plans(:one)
+    patch event_plan_path(plan, event_name: events(:party).name), params: { plan: { title: 'updated title' } }
+
+    plan.reload
+    assert_redirected_to event_plan_path(plan, event_name: events(:party).name)
+    assert_equal 'updated title', plan.title
+  end
+
+  test 'Update plan description' do
+    plan = plans(:one)
+    patch event_plan_path(plan, event_name: events(:party).name), params: { plan: { description: 'updated desc' } }
+
+    plan.reload
+    assert_redirected_to event_plan_path(plan, event_name: events(:party).name)
+    assert_equal 'updated desc', plan.description
+  end
+
+  test 'Update plan visibility' do
+    plan = plans(:one)
+    patch event_plan_path(plan, event_name: events(:party).name), params: { plan: { public: false } }
+
+    plan.reload
+    assert_redirected_to event_plan_path(plan, event_name: events(:party).name)
+    assert_not plan.public
+  end
+
+  test 'Reject update plan if user is not own plan' do
+    patch event_plan_path(plans(:two), event_name: events(:dojo).name), params: { plan: { title: 'update' } }
+
+    assert_response :forbidden
+  end
 end

--- a/test/controllers/schedules_controller_test.rb
+++ b/test/controllers/schedules_controller_test.rb
@@ -13,7 +13,7 @@ class SchedulesControllerTest < ActionDispatch::IntegrationTest
 
     # TODO: don't check private instance variable
     target = @controller.send(:instance_variable_get, :@schedules)
-    assert_equal 5, target.length
+    assert_equal 7, target.length
   end
 
   test 'set variable @schedules for other event' do

--- a/test/fixtures/schedules.yml
+++ b/test/fixtures/schedules.yml
@@ -8,6 +8,14 @@ one:
   track: party_track_a
   language: 0
 
+one_crossover:
+  title: "Schedule title 1 crossover"
+  description: "This is Schedule title 1 crossover description"
+  start_at: 2021-07-20 10:00:00
+  end_at: 2021-07-20 10:40:00
+  track: party_track_b
+  language: 0
+
 two:
   title: "Schedule title 2"
   description: "This is Schedule title 2 description"
@@ -38,6 +46,14 @@ five:
   start_at: 2021-07-21 11:00:00
   end_at: 2021-07-21 11:40:00
   track: party_track_c
+  language: 1
+
+six:
+  title: "Schedule title 6"
+  description: "This is Schedule title 6 description"
+  start_at: 2021-07-21 12:00:00
+  end_at: 2021-07-21 12:40:00
+  track: party_track_a
   language: 1
 
 dojo_one:


### PR DESCRIPTION
## Background

PlansController has very complex update logic because `/:event_name/plan/:plan_id` can modify Plan model and PlanSchedule model. This implementation is very buggy and hard to maintenance.

This PR create new controller ItemsController and extract PlanSchedule model's modification logic from PlansController to one.