### PR TITLE
Fix broken turbo streams response on schedule page.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -82,7 +82,7 @@ class ItemsController < ApplicationController
       @schedule_table.days.each do |day|
         @table = @schedule_table[day]
         @table.rows.each do |row|
-          throw :abort, [row, @table.track_list] if row.schedules.map(&:id).include?(params[:schedule_id])
+          throw :abort, [row, @table.track_list] if row.schedules.map(&:id).include?(@item.schedule.id)
         end
       end
     end

--- a/app/views/schedules/_card.html.erb
+++ b/app/views/schedules/_card.html.erb
@@ -89,6 +89,7 @@
           <div>
             <% if @plan.plan_schedules.map(&:schedule).include?(schedule) # to avoid n+1 %>
               <%= form_with(url: event_item_url(@plan.plan_schedules.find_by(schedule:), event_name: @plan.event.name), method: :delete ) do |form| %>
+                <%= form.hidden_field :mode, value: mode, id: SecureRandom.uuid %>
                 <%= form.submit I18n.t('card.remove'), class: "remove-plan-button p-2 text-sm font-bold min-h-5 normal-button", data: { turbo_frame: "event_#{@event.id}" } %>
               <% end %>
             <% elsif @plan.new_record? %>
@@ -133,6 +134,7 @@
             <% else %>
               <%= form_with(url: event_plan_items_url(plan_id: @plan.id, event_name: @plan.event.name), method: :post ) do |form| %>
                 <%= form.hidden_field :schedule_id, value: schedule.id %>
+                <%= form.hidden_field :mode, value: mode, id: SecureRandom.uuid %>
                 <%= form.submit inactive ? I18n.t('card.inactive') : I18n.t('card.add'), class: "add-plan-button p-2 text-sm font-bold min-h-5 normal-button", disabled: inactive, data: { turbo_frame: "event_#{@event.id}"} %>
               <% end %>
             <% end %>

--- a/test/system/schedules_test.rb
+++ b/test/system/schedules_test.rb
@@ -93,4 +93,22 @@ class SchedulesTest < ApplicationSystemTestCase
     table_rows = all('tr')
     assert table_rows[2].find_button(class: ['remove-plan-button'])
   end
+
+  test 'when one schedule remove from plan, that schedule button to be add button' do
+    visit event_schedules_path(event_name: events(:kaigi).name)
+
+    all(class: ['add-plan-button'])[1].click
+    find(class: ['confirm-terms-of-service-button']).click
+
+    # wait for turbo frame
+    if has_selector?('dialog', visible: true, wait: 0.25.seconds)
+      has_no_selector?('dialog', visible: true, wait: 1.seconds)
+    end
+
+    all(class: ['remove-plan-button'])[0].click
+
+    sleep 1 # FIXME: this is workaround
+    table_rows = all('tr')
+    assert_equal 3, table_rows[2].all(class: ['add-plan-button']).count
+  end
 end


### PR DESCRIPTION
## Background

In #210 , extract ItemsController from PlansController. but copy-and-paste code has broken.

## Fix

- In ItemsController, detect schedule.id from `@item` variable, not parameter.
- Restore hidden field params `mode` on `_card` partial that does not removable.