### PR TITLE
FormControlコンポーネントを追加

### DIFF
--- a/app/views/components/_form_control.html.erb
+++ b/app/views/components/_form_control.html.erb
@@ -1,0 +1,20 @@
+<% if false %>
+必要なパラメータ:
+- label: ラベルテキスト（必須）
+オプションパラメータ:
+- classes: 追加のCSSクラス
+<% end %>
+
+<% classes ||= "" %>
+<% input_id = "input_#{SecureRandom.hex(8)}" %>
+
+<div class="<%= classes %>">
+  <label
+    for="<%= input_id %>"
+    class="block mb-1 text-sm font-bold"
+  >
+    <%= label %>
+  </label>
+
+  <%= yield input_id %>
+</div>

--- a/app/views/components/_text_field.html.erb
+++ b/app/views/components/_text_field.html.erb
@@ -1,7 +1,12 @@
 <% classes ||= "" %>
 <% placeholder ||= "" %>
+<% id ||= nil %>
 <% text_field_classes = [
 "border border-[var(--textColor)] rounded-md px-4 py-2 text-[var(--textColor)] focus:outline-none focus:ring-2 focus:ring-blue-500",
   classes
 ].join(" ") %>
-<input type="text" class="<%= text_field_classes %>" placeholder="<%= placeholder %>" />
+<input type="text"
+  class="<%= text_field_classes %>"
+  placeholder="<%= placeholder %>"
+  <%= "id=#{id}" if id.present? %>
+/>


### PR DESCRIPTION
#219 

![image](https://github.com/user-attachments/assets/c4162eb6-81c1-4f53-b77e-832ef3653f6d)


使い方

```erb
<%= render layout: "components/form_control", locals: { label: "ユーザー名" } do |id| %>
  <%= render "components/text_field",
    id: id,
    classes: "w-full",
    placeholder: "ユーザー名を入力してください"
  %>
<% end %>
```