### PR TITLE
Selectコンポーネントを追加

### DIFF
--- a/app/views/components/_select.html.erb
+++ b/app/views/components/_select.html.erb
@@ -1,0 +1,40 @@
+<% if false %>
+必要なパラメータ:
+- options: 選択肢の配列。単純な値の配列（例：["選択肢1", "選択肢2"]）、またはラベルと値のペアの配列（例：[["ラベル1", "value1"]]）
+オプションパラメータ:
+- classes: 追加のCSSクラス
+- selected: 選択された値
+- id: select要素のID（form_controlと組み合わせて使用する場合に自動で設定される）
+<% end %>
+
+<% classes ||= "" %>
+<% options ||= [] %>
+<% selected ||= nil %>
+<% id ||= nil %>
+<% select_classes = [
+  "border border-[var(--textColor)] rounded-md px-3 py-2 text-[var(--textColor)] focus:outline-none focus:ring-2 focus:ring-blue-500 min-w-[170px] bg-[length:1.25rem] bg-[right_0.5rem_center] bg-no-repeat",
+  classes
+].join(" ") %>
+
+<select
+  class="<%= select_classes %>"
+  <%= "id=#{id}" if id.present? %>
+>
+  <% options.each do |option| %>
+    <% if option.is_a?(Array) %>
+      <option
+        value="<%= option[1] %>"
+        <%= "selected" if option[1].to_s == selected.to_s %>
+      >
+        <%= option[0] %>
+      </option>
+    <% else %>
+      <option
+        value="<%= option %>"
+        <%= "selected" if option.to_s == selected.to_s %>
+      >
+        <%= option %>
+      </option>
+    <% end %>
+  <% end %>
+</select>


### PR DESCRIPTION
#228 

![image](https://github.com/user-attachments/assets/fb1c47f8-e523-4dee-bdd1-9ef50bbf8968)

使い方

```erb
<%= render layout: "components/form_control", locals: { label: "Event Name" } do |id| %>
  <%= render "components/select",
    id: id,
    options: [["事前勉強会", "pre_study"], ["事後勉強会", "post_study"]],
    selected: "pre_study"
  %>
<% end %>
```

デザインでは矢印の左に縦線が入るんですが、疑似要素でうまく実装できなかったでの一旦この状態まで作りました