### PR TITLE
プロフィール画面のUIを調整

### DIFF
--- a/app/views/friends/_qrcode.html.erb
+++ b/app/views/friends/_qrcode.html.erb
@@ -1,7 +1,11 @@
 <div class="w-full">
   <%= @qrcode.html_safe %>
-  <div class="flex flex-col w-full mt-4" data-controller="friend-code" data-friend-code-expires-at-value="<%= @trigger.expires_at.to_i * 1000 %>">
-    <p>expires in <span data-friend-code-target="counter"></span> seconds</p>
-    <a href="<%= new_profile_friend_path %>" class="normal-button mr-2"><%= I18n.t('button.reload') %></a>
+  <div class="flex flex-col w-full mt-4 gap-2 justify-center items-center" data-controller="friend-code" data-friend-code-expires-at-value="<%= @trigger.expires_at.to_i * 1000 %>">
+    <p class="text-sm text-center">expires in <span data-friend-code-target="counter"></span> seconds</p>
+    <a href="<%= new_profile_friend_path %>" class="inline-flex gap-x-1 items-center align-middle justify-center border border-solid border-[#5E626E] bg-[#FCFCFD] rounded-lg whitespace-nowrap px-3 py-2 no-underline text-decoration-none w-fit">
+      <span class="text-base font-bold text-[#131416] block leading-none">
+        <%= I18n.t('button.reload') %>
+      </span>
+    </a>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,7 +17,7 @@
             <h2 class="text-2xl truncate max-w-[calc(100%-2rem)]"><%= @profile.name %></h2>
           </div>
           <div class="ml-2" data-controller="dialog" data-dialog-element-id-value="edit-introduce-dialog">
-            <%= render 'components/button', title: 'Edit', data_action: 'click->dialog#open' %>
+            <%= render 'components/button', title: I18n.t('button.edit'), data_action: 'click->dialog#open' %>
             <%= render 'dialog', profile: @profile %>
           </div>
         </div>


### PR DESCRIPTION
- 編集ボタンの文言を辞書を使って表示する
- QRコードの表示を調整

<img src="https://github.com/user-attachments/assets/8f61f1fc-9054-4dd1-810f-33979f310acb" width="50%" />