### PR TITLE
fix: セッション表示のトグルアイコンの初期状態を修正

### DIFF
--- a/app/javascript/controllers/sessions_controller.js
+++ b/app/javascript/controllers/sessions_controller.js
@@ -1,9 +1,19 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from '@hotwired/stimulus';
 
 // Connects to data-controller="sessions"
 export default class extends Controller {
-  static targets = [ "icon", "sessions", "session" ];
+  static targets = ['icon', 'sessions', 'session'];
   static values = { isOpen: { type: Boolean, default: true } };
+
+  connect () {
+    // アイコンが存在する場合のみ実行（セッションが2件以上ある場合）
+    if (this.hasIconTarget) {
+      // isOpenValueがfalseの場合、アイコンは右向き（閉じている）
+      // isOpenValueがtrueの場合、アイコンは下向き（開いている）
+      this.iconTarget.classList.toggle('fa-angle-right', !this.isOpenValue);
+      this.iconTarget.classList.toggle('fa-angle-down', this.isOpenValue);
+    }
+  }
 
   toggle () {
     if (this.sessionTargets.length < 2) {
@@ -11,12 +21,18 @@ export default class extends Controller {
     }
 
     this.sessionTargets.forEach((el) => {
-      if (!el.classList.contains("selected")) {
-        el.classList.toggle("hidden", this.isOpenValue);
+      if (!el.classList.contains('selected')) {
+        el.classList.toggle('hidden', this.isOpenValue);
       }
     });
-    this.iconTarget.classList.toggle("fa-angle-right", this.isOpenValue);
-    this.iconTarget.classList.toggle("fa-angle-down", !this.isOpenValue);
+
+    // 値を先に変更
     this.isOpenValue = !this.isOpenValue;
+
+    // 変更後の値に基づいてアイコン状態を更新
+    if (this.hasIconTarget) {
+      this.iconTarget.classList.toggle('fa-angle-right', !this.isOpenValue);
+      this.iconTarget.classList.toggle('fa-angle-down', this.isOpenValue);
+    }
   }
 }


### PR DESCRIPTION
- Stimulusコントローラーのconnectメソッドを追加し、ロード時に正しいアイコン状態（
fa-angle-rightとfa-angle-down）を設定するようにした。
- また、トグル操作時の アイコン更新ロジックも修正し、isOpenValueの値と表示状態が常に一致するように
改善した。