### PR TITLE
マイプラン画面にshareボタンは不要なので削除

### DIFF
--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -18,7 +18,6 @@
 
   <div class="flex justify-between items-center mb-2">
     <h2 class="text-2xl font-bold">Your Schedule</h2>
-    <%= render "components/button", title: "Share", size: "s" %>
   </div>
 
   <div class="bg-white rounded-lg p-4 mb-7">


### PR DESCRIPTION
shareボタンはマイプラン画面への動線であるため、マイプラン画面には不要です。

<img src="https://github.com/user-attachments/assets/db575b8a-0551-4680-b352-17966f1ab7c4" width="50%" />
