### PR TITLE
スケジュールページのいくつかの改善

### DIFF
--- a/app/views/components/_button.html.erb
+++ b/app/views/components/_button.html.erb
@@ -5,14 +5,15 @@
 <% disabled ||= false %>
 <% data ||= nil %>
 <% danger ||= false %>
-<% data ||= nil %>
+<% text_size ||= "text-base" %>
 <% button_classes = [
   "inline-flex gap-x-1 items-center align-middle justify-center border border-solid border-[#5E626E] bg-[#FCFCFD] rounded-lg whitespace-nowrap",
   (size == "s" ? "px-2 py-1" : "px-3 py-2"),
   classes
 ].join(" ") %>
 <% text_classes = [
-  "text-base font-bold",
+  text_size,
+  "font-bold",
   (disabled ? "text-[#CDCFD5]" : "text-[#131416]"),
   (danger ? "text-red-600" : nil)
 ].join(" ") %>

--- a/app/views/components/_session.html.erb
+++ b/app/views/components/_session.html.erb
@@ -22,7 +22,7 @@
       <div>から</div>
     <% else %>
       <% row.schedules.each do |session| %>
-        <div data-sessions-target="session" class="<%= session == scheduled ? 'selected' : scheduled ? 'hidden md:block' : '' %> w-[288px]">
+        <div data-sessions-target="session" class="<%= session == scheduled ? 'selected' : scheduled ? 'hidden md:block' : '' %> w-full md:w-[288px]">
           <%= render 'components/session_card',
                      row: row,
                      schedule: session,

--- a/app/views/components/_session_card.html.erb
+++ b/app/views/components/_session_card.html.erb
@@ -32,7 +32,8 @@
       <%= render 'components/button',
                  title: I18n.t('card.add'),
                  icon: render("components/icons/add"),
-                 data: { action: "click->dialog#open" }
+                 data: { action: "click->dialog#open" },
+                 text_size: 'text-sm'
       %>
       <dialog id="<%= terms_of_service_dialog_id %>">
         <%= form_with(url: event_plans_path(@plan, event_name: @plan.event.name), model: @plan, method: :post) do |form| %>
@@ -56,7 +57,8 @@
                  title: I18n.t('card.remove'),
                  icon: render("components/icons/close"),
                  data: { turbo_frame: row.turbo_frames_id },
-                 form_helper: form
+                 form_helper: form,
+                 text_size: 'text-sm'
       %>
     <% end %>
   <% else %>
@@ -67,7 +69,8 @@
                  title: inactive ? I18n.t('card.inactive') : I18n.t('card.add'),
                  icon: render("components/icons/add"),
                  data: { turbo_frame: row.turbo_frames_id },
-                 form_helper: form
+                 form_helper: form,
+                 text_size: 'text-sm'
       %>
     <% end %>
   <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -22,7 +22,7 @@
       <div class="flex justify-between items-center mb-2">
         <h2 class="text-2xl font-bold">Your Schedule</h2>
         <% if @plan.persisted? %>
-          <%= render "components/button", title: "Share", size: "s", href: event_plan_path(@plan, event_name: @event.name) %>
+          <%= render "components/button", title: I18n.t('button.share'), size: "s", href: event_plan_path(@plan, event_name: @event.name) %>
         <% end %>
       </div>
 
@@ -30,7 +30,7 @@
         <div data-controller="dialog" class="bg-white rounded-lg p-4 mb-7">
           <div class="flex justify-between items-center mb-2">
             <h3 class="text-base font-bold"><%= I18n.t('description.title') %></h3>
-            <%= render "components/button", title: "Edit", size: "s", data: { action: 'click->dialog#open' } %>
+            <%= render "components/button", title: I18n.t('button.edit'), size: "s", data: { action: 'click->dialog#open' } %>
           </div>
           <%= form_with(url: event_plan_path(@plan, event_name: @event.name), model: @plan) do |f| %>
             <p class="text-base"><%= @plan.description %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,7 @@ en:
     edit: "Edit"
     save: "Save"
     close: "Close"
+    share: "Share"
     accept_to_add: "Accept and add to Plans"
     make_editable: "Make editable"
     check_password: "Take edit permission"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -73,6 +73,7 @@ ja:
     edit: "編集"
     save: "保存"
     close: "閉じる"
+    share: "共有"
     accept_to_add: "同意して追加する"
     make_editable: "パスワードを入力して編集"
     check_password: "編集可能にする"


### PR DESCRIPTION
- モバイル表示の際にセッションカードがはみ出る問題を修正
- セッションカードのボタンのテキストサイズを小さくする
- スケジュールページのボタンの多言語対応