### PR TITLE
セッションカードのUI改善

### DIFF
--- a/app/views/components/_button.html.erb
+++ b/app/views/components/_button.html.erb
@@ -7,14 +7,14 @@
 <% danger ||= false %>
 <% text_size ||= "text-base" %>
 <% button_classes = [
-  "inline-flex gap-x-1 items-center align-middle justify-center border border-solid border-[#5E626E] bg-[#FCFCFD] rounded-lg whitespace-nowrap",
+  "inline-flex gap-x-1 items-center align-middle justify-center border border-solid bg-[#FCFCFD] rounded-lg whitespace-nowrap",
   (size == "s" ? "px-2 py-1" : "px-3 py-2"),
+  (disabled ? "border-[#E3E5E8] text-[#CDCFD5]" : "border-[#5E626E] text-[#131416]"),
   classes
 ].join(" ") %>
 <% text_classes = [
   text_size,
   "font-bold",
-  (disabled ? "text-[#CDCFD5]" : "text-[#131416]"),
   (danger ? "text-red-600" : nil)
 ].join(" ") %>
 <% form_helper ||= nil %>

--- a/app/views/components/_session.html.erb
+++ b/app/views/components/_session.html.erb
@@ -4,7 +4,7 @@
   <div class="flex items-center justify-between">
     <button data-action="sessions#toggle" class="flex items-center text-left py-2 gap-1 md:hidden">
       <% if row.schedules.size > 1 %>
-        <div class="w-8 h-8 flex items-center justify-center border border-solid border-[#5E626E] rounded-lg">
+        <div class="w-8 h-8 flex items-center justify-center bg-[#FCFCFD] border border-solid border-[#5E626E] rounded-lg">
           <i data-sessions-target="icon" class="fa-solid fa-angle-right md:hidden"></i>
         </div>
       <% end %>

--- a/app/views/components/_session_card.html.erb
+++ b/app/views/components/_session_card.html.erb
@@ -67,6 +67,7 @@
       <%= form.hidden_field :schedule_id, value: schedule.id %>
       <%= render 'components/button',
                  title: inactive ? I18n.t('card.inactive') : I18n.t('card.add'),
+                 disabled: inactive,
                  icon: render("components/icons/add"),
                  data: { turbo_frame: row.turbo_frames_id },
                  form_helper: form,

--- a/app/views/components/_session_card.html.erb
+++ b/app/views/components/_session_card.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-shade-100 shadow-md rounded-lg p-4 flex flex-col gap-y-2">
+<div class="bg-shade-100 shadow-md rounded-lg p-4 flex flex-col gap-y-2 <%= 'border-2 border-[#5E626E]' if scheduled == schedule %>">
   <%# スケジュール情報の展開 %>
   <div class="text-sm"><%= schedule.language %>・<%= schedule.track.name %></div>
   <a href="<%#= FIXME %>" class="text-lg font-semibold text-accent underline underline-offset-4 block h-[56px] overflow-hidden">

--- a/app/views/components/icons/_add.html.erb
+++ b/app/views/components/icons/_add.html.erb
@@ -1,5 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g id="Icon/add">
-<path id="Vector" d="M7.33325 8.66658H3.33325V7.33325H7.33325V3.33325H8.66658V7.33325H12.6666V8.66658H8.66658V12.6666H7.33325V8.66658Z" fill="#131416"/>
+<path id="Vector" d="M7.33325 8.66658H3.33325V7.33325H7.33325V3.33325H8.66658V7.33325H12.6666V8.66658H8.66658V12.6666H7.33325V8.66658Z" fill="currentColor"/>
 </g>
 </svg>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
     add: "Add to my schedule"
     added: "Added to my schedule"
     remove: "Remove from my schedule"
-    inactive: "Another track selected"
+    inactive: "Add to my schedule"
     show_detail: "Show detail"
     detail:
       title: "The details"
@@ -87,7 +87,7 @@ en:
   dialog:
     edit_title: "Edit the title"
     edit_name: "Edit the name"
-    edit_memo: "Edit a note for \"%{title}\""
+    edit_memo: 'Edit a note for "%{title}"'
     terms_of_service: "Terms of service"
     input_password: "Input password"
     manage_members: Members
@@ -136,12 +136,12 @@ en:
     member_exists: "User %{user} is already a member of this team."
 
   teams:
-    name: 'Team name'
-    settings: 'Team settings'
+    name: "Team name"
+    settings: "Team settings"
     tabs:
-      general: 'General'
-      members: 'Members'
-    about: 'About team feature'
+      general: "General"
+      members: "Members"
+    about: "About team feature"
     features:
       - "List all members plan in one page"
       - "User can join to only one team"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,10 +22,10 @@ ja:
     no_plans: "視聴予定のトークを登録しましょう！"
     no_plans_description: "トーク一覧から予定を追加しよう"
   card:
-    add: "スケジュールに追加する"
-    added: "スケジュールに追加されています"
-    remove: "スケジュールから削除します"
-    inactive: "同じ時間のスケジュールが登録されています"
+    add: "スケジュールに追加"
+    added: "スケジュールに追加済み"
+    remove: "スケジュールから削除"
+    inactive: "スケジュールに追加"
     show_detail: "詳細を表示"
     detail:
       title: "トークの詳細"
@@ -93,12 +93,12 @@ ja:
     plan_title: "視聴予定"
 
   teams:
-    name: 'チーム名'
-    settings: 'チーム設定'
+    name: "チーム名"
+    settings: "チーム設定"
     tabs:
-      general: '一般'
-      members: 'メンバー'
-    about: 'チーム機能について'
+      general: "一般"
+      members: "メンバー"
+    about: "チーム機能について"
     features:
       - "同じチームに所属しているメンバーの予定が、一つのページで一覧できるようになります"
       - "ユーザーは1つのチームにしか所属することができません"


### PR DESCRIPTION
- toggleボタンに背景色を追加
- 同じ時間帯のセッションが登録済みの場合はボタンをdisabledにする
- disabled buttonのスタイル修正
- カードの文言がはみ出ないようにする
- 登録済みのセッションのカードにボーダーを付け、登録済みであることを分かりやすくする

<img src="https://github.com/user-attachments/assets/93b9dac7-3967-40f5-a5b9-632ffe6b648e" width="50%" />