### PR TITLE
ノート編集ダイアログのUI

### DIFF
--- a/app/views/components/_dialog.html.erb
+++ b/app/views/components/_dialog.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center">
-  <div class="bg-white rounded-lg w-[480px] max-h-[90vh] flex flex-col">
+  <div class="bg-white rounded-lg w-[90vw] md:w-[480px] max-h-[90vh] flex flex-col">
     <%# ヘッダー部分 %>
     <div class="px-4 py-2 border-b">
       <h2 class="text-xl font-bold">

--- a/app/views/components/_textarea.html.erb
+++ b/app/views/components/_textarea.html.erb
@@ -1,6 +1,7 @@
 <% if false %>
 必要なパラメータ:
-なし
+- form_helper: フォームヘルパーオブジェクト（form_withなどから渡される）
+- attribute: フォームのフィールド名
 
 オプションパラメータ:
 - classes: 追加のCSSクラス
@@ -13,14 +14,20 @@
 <% placeholder ||= "" %>
 <% id ||= nil %>
 <% rows ||= 3 %>
+<% form_helper ||= nil %>
+<% attribute ||= nil %>
 <% textarea_classes = [
   "border border-[var(--textColor)] rounded-md px-3 py-2 text-[var(--textColor)] focus:outline-none focus:ring-2 focus:ring-blue-500 w-full resize-y",
   classes
 ].join(" ") %>
 
-<textarea
-  class="<%= textarea_classes %>"
-  placeholder="<%= placeholder %>"
-  rows="<%= rows %>"
-  <%= "id=#{id}" if id.present? %>
-></textarea>
+<% if form_helper %>
+  <%= form_helper.text_area attribute, class: textarea_classes, placeholder: placeholder, id: id, rows: rows %>
+<% else %>
+  <textarea
+    class="<%= textarea_classes %>"
+    placeholder="<%= placeholder %>"
+    rows="<%= rows %>"
+    <%= "id=#{id}" if id.present? %>
+  ></textarea>
+<% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -36,7 +36,7 @@
             <p class="text-base"><%= @plan.description %></p>
             <dialog data-dialog-target="dialog">
               <%= render 'components/dialog', title: I18n.t("description.form_title"), action_button: { title: I18n.t('button.save'), form_helper: f } do %>
-                <%= render 'components/text_field', form_helper: f, attribute: :description %>
+                <%= render 'components/textarea', form_helper: f, attribute: :description, rows: 5 %>
               <% end %>
             </dialog>
           <% end %>


### PR DESCRIPTION
- モバイルの時はダイアログの横幅を90vwにする
- ノートの入力要素をtextareaにする

<img src="https://github.com/user-attachments/assets/e17c3b51-7a00-45af-9cbb-15224fc89817" width="50%" />