### PR TITLE
ActiveStorage::Attachment record_id type mismatch

### DIFF
--- a/db/migrate/20250327040250_change_active_storage_attachments_record_id_type.rb
+++ b/db/migrate/20250327040250_change_active_storage_attachments_record_id_type.rb
@@ -1,0 +1,5 @@
+class ChangeActiveStorageAttachmentsRecordIdType < ActiveRecord::Migration[8.0]
+  def change
+    change_column :active_storage_attachments, :record_id, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_26_101848) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_27_040250) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
+    t.string "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"


### PR DESCRIPTION
## Bugfix

The active_storage_attachments tables column `record_id` type is bigint, but all of mie database's primary key is String(UUID).
Change type to string.