### PR TITLE
fix: 言語の表示を正しくする

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -14,4 +14,13 @@ class Schedule < ApplicationRecord
   validates :title, presence: true, length: { in: 1..100 }
   validates :description, length: { in: 0..1024 }
   validates :language, presence: true
+
+  def language_text
+    case language
+    when 'en' then 'English'
+    when 'ja' then 'Japanese'
+    when 'en & ja' then 'English & Japanese'
+    else language
+    end
+  end
 end

--- a/app/views/components/_session_card.html.erb
+++ b/app/views/components/_session_card.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-shade-100 shadow-md rounded-lg p-4 flex flex-col gap-y-2 <%= 'border-2 border-[#5E626E]' if scheduled == schedule %>">
   <%# スケジュール情報の展開 %>
-  <div class="text-sm"><%= schedule.language %>・<%= schedule.track.name %></div>
+  <div class="text-sm"><%= schedule.language_text %>・<%= schedule.track.name %></div>
   <a href="<%#= FIXME %>" class="text-lg font-semibold text-accent underline underline-offset-4 block h-[56px] overflow-hidden">
     <span class="line-clamp-2">
       <%= schedule.title %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -106,7 +106,11 @@ ActiveRecord::Base.transaction do
       schedule.update!(
         title: presentation['title'],
         description: presentation['description'],
-        language: presentation['language'].then { Schedule.languages.has_key?(_1) ? _1 : "en & ja" }.downcase
+        language: case presentation['language']
+          when 'EN' then 'en'
+          when 'JA' then 'ja'
+          else 'en & ja'
+        end
       )
     end
   end


### PR DESCRIPTION
#308 
言語表示が`en & ja`となっているのを、セッションの情報に合わせて`Japanese`、`English`と表示するよう修正

<img src="https://github.com/user-attachments/assets/16c3f577-b084-4bc6-bf98-e6dde8a5d3e6" width="50%" />