### PR TITLE
fix: セッションカードのアバター幅が複数表示時に縮小される問題を修正

### DIFF
--- a/app/views/components/_session_card.html.erb
+++ b/app/views/components/_session_card.html.erb
@@ -10,7 +10,9 @@
   <div class="flex flex-col">
     <% schedule.speakers.each do |speaker| %>
       <div class="flex items-center gap-x-2">
-        <%= render 'components/avatar', name: speaker.name, url: speaker.thumbnail, size: 'm' %>
+        <div class="flex-shrink-0">
+          <%= render 'components/avatar', name: speaker.name, url: speaker.thumbnail, size: 'm' %>
+        </div>
         <div>
           <span class="text-sm font-bold"><%= speaker.name %></span>
           <span class="text-sm text-shade-30"><%= speaker.handle %></span>


### PR DESCRIPTION
- アバター要素にflex-shrink-0を追加し、幅の縮小を防止
- セッション数に関わらずアバターの幅（40px）を一定に保持
- 3カラム表示時のアバター圧縮問題を解消