### PR TITLE
公式のセッション詳細画面への動線を追加

### DIFF
--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -13,4 +13,8 @@ class Speaker < ApplicationRecord
   validates :handle, length: { in: 0..100 }
   validates :profile, length: { in: 0..1024 }
   validates :thumbnail, presence: true, length: { in: 0..1024 }
+
+  def handle_without_at
+    handle.to_s.delete_prefix('@')
+  end
 end

--- a/app/views/components/_session_card.html.erb
+++ b/app/views/components/_session_card.html.erb
@@ -1,11 +1,19 @@
 <div class="bg-shade-100 shadow-md rounded-lg p-4 flex flex-col gap-y-2 <%= 'border-2 border-[#5E626E]' if scheduled == schedule %>">
   <%# スケジュール情報の展開 %>
   <div class="text-sm"><%= schedule.language %>・<%= schedule.track.name %></div>
-  <a href="<%#= FIXME %>" class="text-lg font-semibold text-accent underline underline-offset-4 block h-[56px] overflow-hidden">
-    <span class="line-clamp-2">
-      <%= schedule.title %>
-    </span>
-  </a>
+
+  <% common_classes = "text-lg font-semibold text-accent block h-[56px] overflow-hidden" %>
+  <% tag_name = schedule.speakers.first.present? ? :a : :p %>
+  <% tag_options = {
+    class: [common_classes, schedule.speakers.first.present? ? "underline underline-offset-4" : nil].compact,
+    href: schedule.speakers.first.present? ? "https://rubykaigi.org/2025/presentations/#{schedule.speakers.first.handle_without_at}" : nil,
+    target: schedule.speakers.first.present? ? "_blank" : nil
+  }.compact %>
+
+  <%= content_tag(tag_name, **tag_options) do %>
+    <span class="line-clamp-2"><%= schedule.title %></span>
+  <% end %>
+
   <%# 登壇者情報 %>
   <div class="flex flex-col">
     <% schedule.speakers.each do |speaker| %>


### PR DESCRIPTION
https://github.com/kufu/mie/issues/309
※ Lightning Talksだけ公式のセッション詳細画面が無いので、その場合はリンクにならないようにしています

<img src="https://github.com/user-attachments/assets/6831ad99-b353-4657-ad52-4d6ce19de5e1" width="50%" />