### PR TITLE
ノート編集ダイアログのUI改善

### DIFF
--- a/app/views/components/_error_messages.html.erb
+++ b/app/views/components/_error_messages.html.erb
@@ -1,0 +1,7 @@
+<% if errors.present? %>
+  <ul class="mt-2 text-[var(--mainColor)]">
+    <% errors.each do |e| %>
+      <li class="text-sm <%= 'mb-1' unless e == errors.last %>"><%= e.full_message %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/components/_form_control.html.erb
+++ b/app/views/components/_form_control.html.erb
@@ -3,9 +3,11 @@
 - label: ラベルテキスト（必須）
 オプションパラメータ:
 - classes: 追加のCSSクラス
+- errors: エラーメッセージオブジェクト
 <% end %>
 
 <% classes ||= "" %>
+<% errors ||= nil %>
 <% input_id = "input_#{SecureRandom.hex(8)}" %>
 
 <div class="<%= classes %>">
@@ -15,6 +17,8 @@
   >
     <%= label %>
   </label>
-
-  <%= yield input_id %>
+<%= yield input_id %>
+<% if errors.present? %>
+  <%= render 'components/error_messages', errors: errors %>
+<% end %>
 </div>

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -1,31 +1,13 @@
 <%= form_with(url: event_plan_path(plan, event_name: plan.event.name), model: plan) do |f| %>
   <%= render 'components/dialog', title: I18n.t("description.form_title"), action_button: { title: I18n.t('button.save'), form_helper: f } do %>
     <div class="mb-2">
-      <%= render 'components/form_control', input_type: :plan_title, label: :title do %>
-        <%= render 'components/text_field', form_helper: f, attribute: :title %>
-        <% if plan.errors[:title].present? %>
-          <div class="m-2 text-red-500">
-            <ul>
-              <% plan.errors.where(:title).each do |e| %>
-                <li><%= e.full_message %></li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
+      <%= render 'components/form_control', input_type: :plan_title, label: :title, errors: plan.errors.where(:title) do %>
+        <%= render 'components/text_field', form_helper: f, attribute: :title, classes: "w-full" %>
       <% end %>
     </div>
     <div class="mb-2">
-      <%= render 'components/form_control', input_type: :plan_description, label: :description do %>
+      <%= render 'components/form_control', input_type: :plan_description, label: :description, errors: plan.errors.where(:description) do %>
         <%= render 'components/textarea', form_helper: f, attribute: :description, rows: 5 %>
-        <% if plan.errors[:description].present? %>
-          <div class="m-2 text-red-500">
-            <ul>
-              <% plan.errors.where(:description).each do |e| %>
-                <li><%= e.full_message %></li>
-              <% end %>
-            </ul>
-          </div>
-        <% end %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
- form_controlコンポーネントにエラーメッセージ表示機能を追加
- ノート編集ダイアログのinputの横幅調整
- ノート編集ダイアログのエラー表示のスタイルを調整

<img src="https://github.com/user-attachments/assets/63f09a9c-e8d3-44eb-b854-ec6f15cb6327" width="50%" />