### PR TITLE
Add trophy notification with TurboStreams over SolidCable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,5 @@ gem 'mission_control-jobs', '~> 1.0'
 gem 'bootsnap', require: false
 
 gem 'active_storage_db', '~> 1.4'
+
+gem 'solid_cable', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,11 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    solid_cable (3.0.7)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     solid_cache (1.0.6)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -404,6 +409,7 @@ DEPENDENCIES
   rqrcode (~> 2.2)
   rubocop (~> 1.18)
   selenium-webdriver
+  solid_cable (~> 3.0)
   solid_cache (~> 1.0)
   solid_queue (= 1.1.3)
   sqlite3 (~> 2.5)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("hamburger", HamburgerController)
 import LocaleController from "./locale_controller"
 application.register("locale", LocaleController)
 
+import NotificationController from "./notification_controller"
+application.register("notification", NotificationController)
+
 import ScheduleTableController from "./schedule_table_controller"
 application.register("schedule-table", ScheduleTableController)
 

--- a/app/javascript/controllers/notification_controller.js
+++ b/app/javascript/controllers/notification_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="notification"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/notification_controller.js
+++ b/app/javascript/controllers/notification_controller.js
@@ -1,8 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
+import { enter, leave } from "el-transition"
 
 // Connects to data-controller="notification"
 export default class extends Controller {
-  close() {
-    this.element.classList.add("hidden")
+  connect () {
+    enter(this.element);
+  }
+
+  close () {
+    leave(this.element);
   }
 }

--- a/app/javascript/controllers/notification_controller.js
+++ b/app/javascript/controllers/notification_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="notification"
 export default class extends Controller {
-  connect() {
+  close() {
+    this.element.classList.add("hidden")
   }
 }

--- a/app/models/trigger.rb
+++ b/app/models/trigger.rb
@@ -22,14 +22,16 @@ class Trigger < ApplicationRecord
     check_amount
     check_expires
 
+    ret = nil
     transaction do
       action_as_array.each do |act|
-        Action.new(act).perform(target)
+        ret = Action.new(act).perform(target)
       end
 
       self.amount -= 1
       save!
     end
+    ret
   end
 
   def refresh_key

--- a/app/views/components/_button.html.erb
+++ b/app/views/components/_button.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (title:, size: 'default', classes: "", icon: "", disabled: false, data: nil, danger: false, text_size: 'text-base', form_helper: nil, href: nil) -%>
+<%# locals: (title: nil, size: 'default', classes: "", icon: nil, disabled: false, data: nil, danger: false, text_size: 'text-base', form_helper: nil, href: nil) -%>
 
 <% button_classes = [
   "inline-flex gap-x-1 items-center align-middle justify-center border border-solid bg-[var(--semantic-neutral-background)] rounded-lg whitespace-nowrap",
@@ -16,23 +16,35 @@
 
 <% if form_helper %>
   <%= form_helper.button type: :submit, class: button_classes, data: data, disabled: disabled do %>
-    <%= raw icon %>
-    <span class="<%= text_classes %>">
-    <%= title %>
-  </span>
+    <% if icon %>
+      <%= raw icon %>
+    <% end %>
+    <% if title %>
+      <span class="<%= text_classes %>">
+        <%= title %>
+      </span>
+    <% end %>
   <% end %>
 <% elsif href %>
   <%= link_to href, data: data, class: button_classes, disabled: disabled do %>
-    <%= raw icon %>
-    <span class="<%= text_classes %>">
-      <%= title %>
-    </span>
+    <% if icon %>
+      <%= raw icon %>
+    <% end %>
+    <% if title %>
+      <span class="<%= text_classes %>">
+        <%= title %>
+      </span>
+    <% end %>
   <% end %>
 <% else %>
   <%= tag.button class: button_classes, disabled: disabled, data: data do %>
-    <%= raw icon %>
-    <span class="<%= text_classes %>">
-      <%= title %>
-    </span>
+    <% if icon %>
+      <%= raw icon %>
+    <% end %>
+    <% if title %>
+      <span class="<%= text_classes %>">
+        <%= title %>
+      </span>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/components/_notification.html.erb
+++ b/app/views/components/_notification.html.erb
@@ -2,7 +2,13 @@
 
 <div
   data-controller="notification"
-  class="h-12 w-full flex items-center justify-between p-4 border-b bg-[var(--semantic-neutral-background-group)]"
+  class="h-12 w-full flex items-center justify-between p-4 border-b bg-[var(--semantic-neutral-background-group)] hidden"
+  data-transition-enter="transform transition ease-out duration-150"
+  data-transition-enter-start="-translate-y-full opacity-0"
+  data-transition-enter-end="translate-y-0 opacity-100"
+  data-transition-leave="transition ease-out duration-250"
+  data-transition-leave-start="translate-y-0 opacity-100"
+  data-transition-leave-end="-translate-y-full opacity-0"
 >
   <div class="text-xs font-bold"><%= title %></div>
   <%= render "components/button", icon: render("components/icons/close"), size: 's', data: { action: "click->notification#close"} %>

--- a/app/views/components/_notification.html.erb
+++ b/app/views/components/_notification.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (title:) -%>
+
+<div
+  data-controller="notification"
+  class="h-12 w-full flex items-center justify-between p-4 border-b bg-[var(--semantic-neutral-background-group)]"
+>
+  <div class="text-xs font-bold"><%= title %></div>
+  <%= render "components/button", icon: render("components/icons/close"), size: 's', data: { action: "click->notification#close"} %>
+</div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -8,7 +8,7 @@
 
 <%= turbo_frame_tag @event, refresh: :morph do %>
   <div data-controller="schedule-table">
-    <div class="flex justify-center pb-4">
+    <div class="flex justify-center bg-white mx-[calc(50%-50vw)] -mt-4 sm:-mt-8">
       <div class="flex border-b border-[#CDCFD5] w-fit">
         <% @schedule_table.days.each do |day| %>
           <button data-action="click->schedule-table#switch" value="<%= day %>" class="tab-button text-sm text-[var(--semantic-neutral-text)] px-4 pt-2 pb-[5px] border-b-[3px] border-transparent hover:bg-[rgb(248,247,246)]">
@@ -24,7 +24,7 @@
              data-share-title-value="<%= @plan.title %>"
              data-share-text-value="<%= @plan.description %>"
              data-share-url-value="<%= event_plan_url(@plan, event_name: @event.name) %>"
-             class="flex justify-between items-center mb-2"
+             class="flex justify-between items-center my-2"
         >
           <h2 class="text-2xl font-bold text-[var(--semantic-neutral-text)]"><%= @plan.title %></h2>
           <% if @plan.persisted? %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -18,13 +18,16 @@
       </div>
     </div>
 
+    <%= turbo_stream_from @user.id, :notification %>
+    <div id="notification" class="mb-4 mx-[calc(50%-50vw)] sticky top-0 z-50"></div>
+
     <% unless @plan.new_record? %>
       <%= turbo_frame_tag @plan do %>
         <div data-controller="share"
              data-share-title-value="<%= @plan.title %>"
              data-share-text-value="<%= @plan.description %>"
              data-share-url-value="<%= event_plan_url(@plan, event_name: @event.name) %>"
-             class="flex justify-between items-center my-2"
+             class="flex justify-between items-center mb-2"
         >
           <h2 class="text-2xl font-bold text-[var(--semantic-neutral-text)]"><%= @plan.title %></h2>
           <% if @plan.persisted? %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -3,7 +3,12 @@
 # not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
 # to make the web console appear.
 development:
-  adapter: async
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
 
 test:
   adapter: test

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,8 +1,17 @@
+# Async adapter only works within the same process, so for manually triggering cable updates from a console,
+# and seeing results in the browser, you must do so from the web console (running inside the dev process),
+# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
+# to make the web console appear.
 development:
   adapter: async
 
 test:
   adapter: test
 
-productrion:
-  adapter: async # for dummy, currently ActionCable is not used
+production:
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day

--- a/config/database.yml
+++ b/config/database.yml
@@ -33,6 +33,10 @@ development:
     <<: *primary_development
     database: storage/development_queue.sqlite3
     migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_development
+    database: storage/development_cable.sqlite3
+    migrations_paths: db/cable_migrate
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -100,3 +104,7 @@ production:
     <<: *primary_development
     database: storage/production_queue.sqlite3
     migrations_paths: db/queue_migrate
+  cable:
+    <<: *primary_production
+    database: storage/production_cable.sqlite3
+    migrations_paths: db/cable_migrate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,7 @@ en:
 
   trophy:
     rarity: "Rarity"
+    notification: "🏆「[%{name}] unlocked!"
 
   trigger:
     error: "Already satisfied the condition"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,8 +154,7 @@ en:
 
   trophy:
     rarity: "Rarity"
-    notification: "🏆「[%{name}] unlocked!"
-
+    notification: "🏆 [%{name}] unlocked!"
   trigger:
     error: "Already satisfied the condition"
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -111,6 +111,7 @@ ja:
 
   trophy:
     rarity: "レアリティ"
+    notification: "🏆「%{name}」を獲得しました！"
 
   trigger:
     error: "すでに条件を満たしています"

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,11 @@
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "channel_hash", limit: 8, null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,4 +1,16 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 1) do
   create_table "solid_cable_messages", force: :cascade do |t|
     t.binary "channel", limit: 1024, null: false
     t.binary "payload", limit: 536870912, null: false

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.3",
     "dayjs": "^1.11.10",
+    "el-transition": "^0.0.7",
     "esbuild": "^0.20.1",
     "prop-types": "^15.7.2",
     "typescript": "^4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+el-transition@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/el-transition/-/el-transition-0.0.7.tgz#714fd47aa46fc2ff3df7d59e789271aa09f247d0"
+  integrity sha512-a23pEa7ahqLmBIEqtxi8CdL6CRLF52ZoAwawDFTD1IDkegrL4iValQAj6IMEgIEXPSrXZtx/Nr/ej6ebov4uoA==
+
 es-abstract@^1.22.1, es-abstract@^1.22.3:
   version "1.22.5"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.5.tgz#1417df4e97cc55f09bf7e58d1e614bc61cb8df46"


### PR DESCRIPTION
## Features

Add trophy notification. This component works with TurboStreams and SolidCable.

When a trophy is earned, a SolidQueue job sends the TurboStreams frame over ActionCable and notify the client that the trophy has been unlocked.

https://github.com/user-attachments/assets/d7a25984-0876-46aa-b7fe-02e7c9552537

## Prepare

To launch the SolidCable, execute following command.

```shell
bin/rails db:prepare
```