### PR TITLE
[CLAUDE] wkhtmltopdfをaptではなくバイナリから直接インストールするように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,14 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips sqlite3 wkhtmltopdf fonts-noto-cjk fonts-noto-color-emoji && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 libvips sqlite3 fonts-noto-cjk fonts-noto-color-emoji && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Install wkhtmltopdf from binary (not available via apt on Debian Trixie)
+RUN curl -fsSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_amd64.deb -o /tmp/wkhtmltox.deb && \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y /tmp/wkhtmltox.deb && \
+    rm -rf /tmp/wkhtmltox.deb /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
 ENV RAILS_ENV="production" \


### PR DESCRIPTION
プロンプト:
ベースイメージの ruby:4.0.2 では、Trixieベースですが wkhtmltopdf がaptで入れられなくなっています。直接バイナリをインストールするように、Dockerfileを書き換えてください。

修正内容:
- aptパッケージ一覧からwkhtmltopdfを削除
- wkhtmltopdf 0.12.6.1-3のbookworm向けdebパッケージをGitHub Releasesからダウンロードし、dpkgでインストールするRUNステップを追加
- Debian Trixie(ruby:4.0.2-slimのベース)ではwkhtmltopdfがaptリポジトリに存在しないため、直接バイナリインストールに切り替えた