### PR TITLE
Adjust RubyKaigi logo size in the header

### DIFF
--- a/app/views/components/_app_header.html.erb
+++ b/app/views/components/_app_header.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       <% unless Rails.env.test? %>
         <a href="https://rubykaigi.org/2026/" target="_blank">
-          <img class="h-3" src="<%= asset_path("#{event.name}/rubykaigi_logo.svg") %>" alt="RubyKaigi #{event.name}">
+          <img class="h-5 w-auto sm:h-6" src="<%= asset_path("#{event.name}/rubykaigi_logo.svg") %>" alt="RubyKaigi #{event.name}">
         </a>
       <% end %>
     </div>


### PR DESCRIPTION
Increase the header logo image height from the previous tiny fixed size to a larger responsive size so the RubyKaigi branding remains legible on mobile and desktop without changing the overall header structure.