### PR TITLE
Highlight current/next session

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -46,4 +46,12 @@
   .tab-btn-active {
     @apply relative text-[var(--semantic-neutral-text)] font-bold border-[var(--semantic-neutral-line)];
   }
+
+  .event-current {
+    background-color: rgb(105, 217, 222) !important;
+  }
+
+  .event-next {
+    background-color: rgba(105, 217, 222, 0.3) !important;
+  }
 }

--- a/app/javascript/controllers/schedule_table_controller.js
+++ b/app/javascript/controllers/schedule_table_controller.js
@@ -2,10 +2,15 @@ import { Controller } from '@hotwired/stimulus';
 
 // Connects to data-controller="schedule-table"
 export default class extends Controller {
+  static targets = ['row'];
+
   connect () {
     const id = window.location.hash;
     const tables = document.getElementsByClassName('schedule-table');
     const buttons = document.getElementsByClassName('tab-button');
+
+    this.highlightCurrentEvent();
+    this.highlightTimer = setInterval(() => this.highlightCurrentEvent(), 60 * 1000);
 
     if (tables.length <= 0) {
       return;
@@ -44,6 +49,17 @@ export default class extends Controller {
     });
   }
 
+  disconnect () {
+    if (this.highlightTimer) {
+      clearInterval(this.highlightTimer);
+      this.highlightTimer = null;
+    }
+  }
+
+  rowTargetConnected () {
+    this.highlightCurrentEvent();
+  }
+
   switch (event) {
     const tables = document.getElementsByClassName('schedule-table');
     const target = document.getElementById('schedule-' + event.currentTarget.value);
@@ -64,5 +80,32 @@ export default class extends Controller {
     event.currentTarget.classList.add('tab-btn-active');
 
     window.location.hash = '#' + event.currentTarget.value;
+  }
+
+  highlightCurrentEvent () {
+    const now = new Date();
+
+    this.rowTargets.forEach((row) => {
+      row.classList.remove('event-current', 'event-next');
+    });
+
+    const rows = this.rowTargets
+      .map((el) => ({
+        el,
+        startAt: new Date(el.dataset.startAt),
+        endAt: new Date(el.dataset.endAt)
+      }))
+      .sort((a, b) => a.startAt - b.startAt);
+
+    const current = rows.find(({ startAt, endAt }) => startAt <= now && now < endAt);
+    if (current) {
+      current.el.classList.add('event-current');
+      return;
+    }
+
+    const next = rows.find(({ startAt }) => startAt > now);
+    if (next) {
+      next.el.classList.add('event-next');
+    }
   }
 }

--- a/app/models/schedule/table/row.rb
+++ b/app/models/schedule/table/row.rb
@@ -3,13 +3,15 @@
 class Schedule
   class Table
     class Row
-      attr_reader :start_at, :end_at, :start_end, :timezone, :schedules, :tracks, :sort_key
+      attr_reader :start_at, :end_at, :start_end, :started_at, :ended_at, :timezone, :schedules, :tracks, :sort_key
 
       def initialize(schedules)
         @start_at = I18n.l(schedules[0].start_at, format: :timetable)
         @end_at = I18n.l(schedules[0].end_at, format: :timetable)
 
         @start_end = "#{@start_at} - #{@end_at}"
+        @started_at = schedules[0].start_at
+        @ended_at = schedules[0].end_at
         @timezone = schedules[0].end_at.strftime('%Z')
         @schedules = schedules
         @tracks = schedules.to_h { [it.track.name, it] }

--- a/app/views/components/_session.html.erb
+++ b/app/views/components/_session.html.erb
@@ -1,6 +1,12 @@
 <%# locals: (row:, location:, scheduled:, team: nil, friends_schedules_map: [], teammates_schedules_map: [], no_buttons: false) -%>
 
-<div data-controller="sessions" data-sessions-is-open-value="<%= !scheduled %>" data-sessions-key-value="<%= row.turbo_frames_id %>" class="bg-primitive-shade-80 rounded-lg p-3 shadow-md border">
+<div data-controller="sessions"
+     data-sessions-is-open-value="<%= !scheduled %>"
+     data-sessions-key-value="<%= row.turbo_frames_id %>"
+     data-schedule-table-target="row"
+     data-start-at="<%= row.started_at.iso8601 %>"
+     data-end-at="<%= row.ended_at.iso8601 %>"
+     class="bg-primitive-shade-80 rounded-lg p-3 shadow-md border">
   <div class="flex items-center justify-between">
     <button data-action="sessions#toggle" class="flex items-center text-left py-2 gap-1 md:hidden">
       <% if row.schedules.size > 1 %>


### PR DESCRIPTION
I added highlight current/next session on the schedule page. Make it instantly obvious which session is running right now on the schedule pages. 

<img width="640" height="571" alt="スクリーンショット 2026-04-24 15 20 39" src="https://github.com/user-attachments/assets/9c008f83-77f1-4617-b720-a0d63c039929" />

I picked up highlight color from [SmartHR Aqua color](https://smarthr.design/basics/colors/).

<img width="1202" height="471" alt="スクリーンショット 2026-04-24 15 21 26" src="https://github.com/user-attachments/assets/30e38952-8934-48a0-bf16-cb205f6737c6" />

During breaks, the next upcoming session is highlighted instead, so attendees always know where to head next.